### PR TITLE
fix: roll from local pool when completely offline

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -90,11 +90,8 @@ class WallpaperService: Service() {
 
 		val online = isOnline()
 		stateRepository.update { it.copy(isOnline = online) }
-		if (!online) {
-			return
-		}
 
-		val canDownload = forceDownload || !settings.wifiOnly || isOnWifi()
+		val canDownload = online && (forceDownload || !settings.wifiOnly || isOnWifi())
 
 		if (canDownload) {
 			val result = wallhavenRepository.next(settings)


### PR DESCRIPTION
## Summary
- Folds the online check into `canDownload` instead of early-returning when offline
- The pool-rolling `else` branch now fires for both offline and Wi-Fi-only-on-mobile cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)