### PR TITLE
fix: prevent Retrofit from URL-encoding the ratios comma

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/data/api/WallhavenApiService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/data/api/WallhavenApiService.kt
@@ -10,7 +10,7 @@ interface WallhavenApiService {
 		@Query("q") query: String?,
 		@Query("categories") categories: String,
 		@Query("purity") purity: String,
-		@Query("ratios") ratios: String?,
+		@Query(value = "ratios", encoded = true) ratios: String?,
 		@Query("sorting") sorting: String,
 		@Query("seed") seed: String?,
 		@Query("apikey") apiKey: String?


### PR DESCRIPTION
## Summary

- `@Query("ratios")` was URL-encoding commas to `%2C`, so `9x16,10x16` arrived at Wallhaven as a single unrecognized ratio string and returned 0 results
- Added `encoded = true` so the comma is passed as-is and Wallhaven parses it as two separate ratios
- Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Resolves https://github.com/Attacktive/Wallhavend-android/issues/7.