### PR TITLE
UI polish: version in title, tappable radio rows

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import xyz.attacktive.wallhavend.BuildConfig
 import xyz.attacktive.wallhavend.domain.model.AppError
 import xyz.attacktive.wallhavend.domain.model.ServiceState
 
@@ -62,7 +63,7 @@ fun HomeScreen(onNavigateToSettings: () -> Unit, viewModel: HomeViewModel = hilt
 	Scaffold(
 		topBar = {
 			TopAppBar(
-				title = { Text("Wallhavend") },
+				title = { Text("Wallhavend ${BuildConfig.VERSION_NAME}") },
 				actions = {
 					IconButton(onClick = onNavigateToSettings) {
 						Icon(Icons.Default.Settings, contentDescription = "Settings")

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -313,11 +313,13 @@ private fun ScheduleTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 	)
 
 	WallpaperTarget.entries.forEach { target ->
-		Row(verticalAlignment = Alignment.CenterVertically) {
-			RadioButton(
-				selected = settings.wallpaperTarget == target,
-				onClick = { onSave(settings.copy(wallpaperTarget = target)) }
-			)
+		Row(
+			verticalAlignment = Alignment.CenterVertically,
+			modifier = Modifier
+				.fillMaxWidth()
+				.clickable { onSave(settings.copy(wallpaperTarget = target)) }
+		) {
+			RadioButton(selected = settings.wallpaperTarget == target, onClick = null)
 
 			Text(
 				text = when (target) {
@@ -365,10 +367,15 @@ private fun AdvancedTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 	)
 
 	POOL_SIZE_OPTIONS.forEach { size ->
-		Row(verticalAlignment = Alignment.CenterVertically) {
+		Row(
+			verticalAlignment = Alignment.CenterVertically,
+			modifier = Modifier
+				.fillMaxWidth()
+				.clickable { onSave(settings.copy(poolSize = size)) }
+		) {
 			RadioButton(
 				selected = settings.poolSize == size,
-				onClick = { onSave(settings.copy(poolSize = size)) }
+				onClick = null
 			)
 
 			Text(


### PR DESCRIPTION
## Summary
- Display app version name in the Home screen top app bar title (e.g. `Wallhavend 1.0.4`) via `BuildConfig.VERSION_NAME`
- Make radio button rows (Wallpaper Target, Pool Size) fully tappable — clicking the label now selects the option, not just the radio circle

🤖 Generated with [Claude Code](https://claude.com/claude-code)