### PR TITLE
fix: warn user when API key combined with aspect ratio yields no results

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppError.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppError.kt
@@ -2,6 +2,7 @@ package xyz.attacktive.wallhavend.domain.model
 
 sealed class AppError {
 	data object NoResults: AppError()
+	data object NoResultsWithRatioHint: AppError()
 	data class ApiError(val code: Int): AppError()
 	data object UnsupportedFormat: AppError()
 	data class WallpaperApplyFailed(val cause: String): AppError()

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -130,7 +130,12 @@ class WallpaperService: Service() {
 				},
 				onFailure = { throwable ->
 					val error = when (throwable) {
-						is NoResultsException -> AppError.NoResults
+						// Wallhaven server bug: certain ratios yield zero results when an API key is present
+						is NoResultsException -> if (settings.apiKey.isNotBlank() && settings.aspectRatio.isNotBlank()) {
+							AppError.NoResultsWithRatioHint
+						} else {
+							AppError.NoResults
+						}
 						is UnsupportedFormatException -> AppError.UnsupportedFormat
 						is HttpException -> AppError.ApiError(throwable.code())
 						else -> AppError.NetworkError(throwable.message ?: throwable.javaClass.simpleName)

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
@@ -210,6 +210,7 @@ private fun WallpaperGrid(paths: List<String>, currentPath: String?, onTap: (Str
 private fun ErrorBanner(error: AppError) {
 	val message = when (error) {
 		is AppError.NoResults -> "No results — try relaxing your filters"
+		is AppError.NoResultsWithRatioHint -> "No results — try clearing the aspect ratio, or remove the API key if you don't need NSFW wallpapers"
 		is AppError.ApiError -> "API error ${error.code}"
 		is AppError.UnsupportedFormat -> "Unsupported image format — skipping"
 		is AppError.WallpaperApplyFailed -> "Failed to apply wallpaper: ${error.cause}"


### PR DESCRIPTION
## Summary

- Adds a new `NoResultsWithRatioHint` error variant triggered when both `apiKey` and `aspectRatio` are set and the API returns zero results
- Shows a targeted message: *"No results — try clearing the aspect ratio, or remove the API key if you don't need NSFW wallpapers"*
- Documents the root cause in code: Wallhaven server bug where certain ratio filters yield zero results when an API key is present

## Test plan

- [x] Set an API key and a portrait aspect ratio (e.g. `9x16`) — confirm the specific hint message appears
- [ ] Set an API key with no aspect ratio — confirm the generic "try relaxing your filters" message appears
- [ ] No API key with any aspect ratio — confirm the generic message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)