### PR TITLE
fix: verify internet access by checking NET_CAPABILITY_VALIDATED

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -221,8 +221,11 @@ class WallpaperService: Service() {
 	private fun isOnline(): Boolean {
 		val cm = getSystemService(ConnectivityManager::class.java)
 
-		return cm.activeNetwork?.let { cm.getNetworkCapabilities(it) }
-			?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+		val isConnected = cm.activeNetwork
+			?.let { cm.getNetworkCapabilities(it) }
+			?.let { it.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) && it.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) }
+
+		return isConnected == true
 	}
 
 	private fun isOnWifi(): Boolean {


### PR DESCRIPTION
## Problem
`WallpaperService.isOnline()` only checks `NET_CAPABILITY_INTERNET`, which indicates the network claims to have internet access — not that it actually works. On captive portal networks (hotel Wi-Fi, etc.), this returns `true` even though real traffic is blocked, causing download attempts to fail instead of being deferred.

## Solution
Also check `NET_CAPABILITY_VALIDATED` to confirm real internet access.

Resolves https://github.com/Attacktive/Wallhavend-android/issues/13.