### PR TITLE
fix: surface settings save errors to the user

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -10,11 +10,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.Purity
 import xyz.attacktive.wallhavend.domain.model.WallhavenCategory
@@ -23,7 +19,6 @@ import xyz.attacktive.wallhavend.util.AppLogger
 
 @Singleton
 class SettingsRepository @Inject constructor(private val dataStore: DataStore<Preferences>, private val logger: AppLogger) {
-	private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 	private object Keys {
 		val SEARCH_QUERY = stringPreferencesKey("search_query")
 		val CATEGORIES = stringSetPreferencesKey("categories")
@@ -64,31 +59,23 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 			.also { logger.d(TAG, "read: ${it.redactedForLog()}") }
 		}
 
-	fun save(settings: AppSettings) {
+	suspend fun save(settings: AppSettings) {
 		logger.d(TAG, "save: ${settings.redactedForLog()}")
 
-		scope.launch {
-			logger.d(TAG, "save() coroutine started on ${Thread.currentThread().name}")
-
-			runCatching {
-				dataStore.edit { prefs ->
-					prefs[Keys.SEARCH_QUERY] = settings.searchQuery
-					prefs[Keys.CATEGORIES] = settings.categories.map { it.name }.toSet()
-					prefs[Keys.PURITY] = settings.purity.map { it.name }.toSet()
-					prefs[Keys.ASPECT_RATIO] = settings.aspectRatio
-					prefs[Keys.UPDATE_INTERVAL_MINUTES] = settings.updateIntervalMinutes
-					prefs[Keys.WALLPAPER_TARGET] = settings.wallpaperTarget.name
-					prefs[Keys.WIFI_ONLY] = settings.wifiOnly
-					prefs[Keys.POOL_SIZE] = settings.poolSize
-					prefs[Keys.API_KEY] = settings.apiKey
-					prefs[Keys.AUTO_START_ON_BOOT] = settings.autoStartOnBoot
-				}
-			}.onSuccess {
-				logger.d(TAG, "save() completed successfully")
-			}.onFailure { e ->
-				logger.e(TAG, "save() FAILED: ${e.message}", e)
-			}
+		dataStore.edit { prefs ->
+			prefs[Keys.SEARCH_QUERY] = settings.searchQuery
+			prefs[Keys.CATEGORIES] = settings.categories.map { it.name }.toSet()
+			prefs[Keys.PURITY] = settings.purity.map { it.name }.toSet()
+			prefs[Keys.ASPECT_RATIO] = settings.aspectRatio
+			prefs[Keys.UPDATE_INTERVAL_MINUTES] = settings.updateIntervalMinutes
+			prefs[Keys.WALLPAPER_TARGET] = settings.wallpaperTarget.name
+			prefs[Keys.WIFI_ONLY] = settings.wifiOnly
+			prefs[Keys.POOL_SIZE] = settings.poolSize
+			prefs[Keys.API_KEY] = settings.apiKey
+			prefs[Keys.AUTO_START_ON_BOOT] = settings.autoStartOnBoot
 		}
+
+		logger.d(TAG, "save() completed")
 	}
 
 	suspend fun saveServiceState(lastUpdatedMs: Long, currentPath: String?, previousPath: String?) {

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
@@ -3,7 +3,6 @@ package xyz.attacktive.wallhavend.ui.home
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -26,8 +25,8 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.Button
@@ -47,6 +46,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -128,7 +128,7 @@ private fun StatusCard(state: ServiceState) {
 
 				state.lastUpdatedMs?.let {
 					Text(
-						text = "Last: ${SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(it))}",
+						text = "Last: ${SimpleDateFormat("HH:mm", LocalLocale.current.platformLocale).format(Date(it))}",
 						style = MaterialTheme.typography.bodySmall
 					)
 				}

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -17,19 +17,22 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -68,10 +71,24 @@ fun SettingsScreen(
 	viewModel: SettingsViewModel = hiltViewModel()
 ) {
 	val settings by viewModel.settings.collectAsStateWithLifecycle()
+	val saveError by viewModel.saveError.collectAsStateWithLifecycle()
 	var selectedTab by rememberSaveable { mutableIntStateOf(0) }
 	val tabs = listOf("Content", "Schedule", "Advanced")
+	val snackbarHostState = remember { SnackbarHostState() }
+
+	LaunchedEffect(saveError) {
+		if (saveError != null) {
+			snackbarHostState.showSnackbar("Failed to save settings: $saveError")
+			viewModel.clearSaveError()
+		}
+	}
 
 	Scaffold(
+		snackbarHost = {
+			SnackbarHost(snackbarHostState) { data ->
+				Snackbar(snackbarData = data, containerColor = MaterialTheme.colorScheme.errorContainer, contentColor = MaterialTheme.colorScheme.onErrorContainer)
+			}
+		},
 		topBar = {
 			TopAppBar(
 				title = { Text("Settings") },
@@ -88,7 +105,7 @@ fun SettingsScreen(
 				.fillMaxSize()
 				.padding(padding)
 		) {
-			TabRow(selectedTabIndex = selectedTab) {
+			PrimaryTabRow(selectedTabIndex = selectedTab) {
 				tabs.forEachIndexed { index, title ->
 					Tab(
 						selected = selectedTab == index,
@@ -284,7 +301,7 @@ private fun ScheduleTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 			trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = intervalExpanded) },
 			modifier = Modifier
 				.fillMaxWidth()
-				.menuAnchor(MenuAnchorType.PrimaryNotEditable)
+				.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
 		)
 
 		ExposedDropdownMenu(expanded = intervalExpanded, onDismissRequest = { intervalExpanded = false }) {

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsViewModel.kt
@@ -4,9 +4,12 @@ import javax.inject.Inject
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
 
@@ -15,5 +18,17 @@ class SettingsViewModel @Inject constructor(private val settingsRepository: Sett
 	val settings: StateFlow<AppSettings> = settingsRepository.settings
 		.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppSettings())
 
-	fun save(settings: AppSettings) = settingsRepository.save(settings)
+	private val _saveError = MutableStateFlow<String?>(null)
+	val saveError = _saveError.asStateFlow()
+
+	fun save(settings: AppSettings) {
+		viewModelScope.launch {
+			runCatching { settingsRepository.save(settings) }
+				.onFailure { e -> _saveError.value = e.message ?: "Failed to save settings" }
+		}
+	}
+
+	fun clearSaveError() {
+		_saveError.value = null
+	}
 }


### PR DESCRIPTION
## Summary

- `SettingsRepository.save()` is now a `suspend fun`; write failures propagate to the caller instead of being logged and dropped
- `SettingsViewModel` catches failures in `viewModelScope` and exposes them via `saveError: StateFlow<String?>`
- `SettingsScreen` shows a Snackbar in error colours when a write fails and clears the error after display
- Replace deprecated `TabRow` with `PrimaryTabRow`
- Use `LocalLocale.current.platformLocale` instead of `Locale.getDefault()` in `StatusCard` so the timestamp recomposes on locale change

Fixes https://github.com/Attacktive/Wallhavend-android/issues/15

## Changes

SettingsRepository — https://github.com/Attacktive/Wallhavend-android/blob/a140d856568315cc36750502e77c5017992bd592/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt#L67-L83

SettingsViewModel — https://github.com/Attacktive/Wallhavend-android/blob/a140d856568315cc36750502e77c5017992bd592/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsViewModel.kt#L22-L34

SettingsScreen Snackbar — https://github.com/Attacktive/Wallhavend-android/blob/a140d856568315cc36750502e77c5017992bd592/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt#L79-L91

StatusCard locale — https://github.com/Attacktive/Wallhavend-android/blob/803c32fa0385c8fa537088d237f108b110db31b3/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt#L131

🤖 Generated with [Claude Code](https://claude.ai/code)