### PR TITLE
fix: replace hardcoded status color with theme primary

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
@@ -123,7 +123,7 @@ private fun StatusCard(state: ServiceState) {
 				Text(
 					text = if (state.isRunning) "● AUTO-UPDATE ON" else "○ AUTO-UPDATE OFF",
 					style = MaterialTheme.typography.labelMedium,
-					color = if (state.isRunning) Color(0xFF90EE90) else MaterialTheme.colorScheme.onSurfaceVariant
+					color = if (state.isRunning) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
 				)
 
 				state.lastUpdatedMs?.let {


### PR DESCRIPTION
## Summary

Replace `Color(0xFF90EE90)` in `StatusCard` with `MaterialTheme.colorScheme.primary`. The hardcoded green is low-contrast on light themes and bypasses Material You dynamic color entirely. `colorScheme.primary` carries the correct active/on semantic and adapts to light/dark mode and user-chosen palettes.

## Changes

https://github.com/Attacktive/Wallhavend-android/blob/16db541/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt#L126

Fixes https://github.com/Attacktive/Wallhavend-android/issues/14

🤖 Generated with [Claude Code](https://claude.ai/code)