### PR TITLE
feature: restore pool and service state from disk on startup

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/ServiceStateRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/ServiceStateRepository.kt
@@ -3,7 +3,6 @@ package xyz.attacktive.wallhavend.domain.repository
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import xyz.attacktive.wallhavend.domain.model.ServiceState
@@ -11,7 +10,7 @@ import xyz.attacktive.wallhavend.domain.model.ServiceState
 @Singleton
 class ServiceStateRepository @Inject constructor() {
 	private val _state = MutableStateFlow(ServiceState())
-	val state: StateFlow<ServiceState> = _state.asStateFlow()
+	val state = _state.asStateFlow()
 
 	fun update(transform: (ServiceState) -> ServiceState) {
 		_state.update(transform)

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.Purity
@@ -77,6 +78,14 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 
 		logger.d(TAG, "save() completed")
 	}
+
+	suspend fun loadServiceState() = dataStore.data.first()
+		.run {
+			Triple(get(Keys.LAST_UPDATED_MS),
+				get(Keys.CURRENT_WALLPAPER_PATH),
+				get(Keys.PREVIOUS_WALLPAPER_PATH)
+			)
+		}
 
 	suspend fun saveServiceState(lastUpdatedMs: Long, currentPath: String?, previousPath: String?) {
 		dataStore.edit { prefs ->

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -65,8 +65,14 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 
 		dataStore.edit { prefs ->
 			prefs[Keys.SEARCH_QUERY] = settings.searchQuery
-			prefs[Keys.CATEGORIES] = settings.categories.map { it.name }.toSet()
-			prefs[Keys.PURITY] = settings.purity.map { it.name }.toSet()
+			prefs[Keys.CATEGORIES] = settings.categories
+				.map { it.name }
+				.toSet()
+
+			prefs[Keys.PURITY] = settings.purity
+				.map { it.name }
+				.toSet()
+
 			prefs[Keys.ASPECT_RATIO] = settings.aspectRatio
 			prefs[Keys.UPDATE_INTERVAL_MINUTES] = settings.updateIntervalMinutes
 			prefs[Keys.WALLPAPER_TARGET] = settings.wallpaperTarget.name

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -111,4 +111,8 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 
 /** Renders settings for logging without exposing the API key. */
 private fun AppSettings.redactedForLog(): AppSettings =
-	if (apiKey.isEmpty()) this else copy(apiKey = "***")
+	if (apiKey.isEmpty()) {
+		this
+	} else {
+		copy(apiKey = "***")
+	}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
@@ -54,7 +54,8 @@ class WallhavenRepository @Inject constructor(private val api: WallhavenApiServi
 		val dto = cache.removeFirst()
 		val wallpaper = dto.toDomain()
 
-		return fileManager.download(wallpaper).map { file -> Pair(wallpaper, file) }
+		return fileManager.download(wallpaper)
+			.map { file -> Pair(wallpaper, file) }
 	}
 
 	private suspend fun refetch(key: SearchKey) = runCatching {

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperFileManager.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperFileManager.kt
@@ -45,7 +45,8 @@ class WallpaperFileManager(private val wallpaperDir: File, private val okHttpCli
 	fun trimToSize(maxSize: Int): List<File> {
 		val all = sortedFiles()
 
-		all.drop(maxSize).forEach { it.delete() }
+		all.drop(maxSize)
+			.forEach { it.delete() }
 
 		return all.take(maxSize)
 	}

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
@@ -82,7 +82,13 @@ fun HomeScreen(onNavigateToSettings: () -> Unit, viewModel: HomeViewModel = hilt
 			Spacer(modifier = Modifier.height(12.dp))
 			QuickActions(
 				state = state,
-				onStartStop = { if (state.isRunning) viewModel.stopService() else viewModel.startService() },
+				onStartStop = {
+					if (state.isRunning) {
+						viewModel.stopService()
+					} else {
+						viewModel.startService()
+					}
+				},
 				onUpdateNow = viewModel::updateNow
 			)
 
@@ -123,7 +129,11 @@ private fun StatusCard(state: ServiceState) {
 				Text(
 					text = if (state.isRunning) "● AUTO-UPDATE ON" else "○ AUTO-UPDATE OFF",
 					style = MaterialTheme.typography.labelMedium,
-					color = if (state.isRunning) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+					color = if (state.isRunning) {
+						MaterialTheme.colorScheme.primary
+					} else {
+						MaterialTheme.colorScheme.onSurfaceVariant
+					}
 				)
 
 				state.lastUpdatedMs?.let {
@@ -142,7 +152,11 @@ private fun QuickActions(state: ServiceState, onStartStop: () -> Unit, onUpdateN
 	Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
 		Button(onClick = onStartStop) {
 			Icon(
-				imageVector = if (state.isRunning) Icons.Default.Stop else Icons.Default.PlayArrow,
+				imageVector = if (state.isRunning) {
+					Icons.Default.Stop
+				} else {
+					Icons.Default.PlayArrow
+				},
 				contentDescription = null
 			)
 
@@ -174,10 +188,14 @@ private fun WallpaperGrid(paths: List<String>, currentPath: String?, onTap: (Str
 					.aspectRatio(9f / 16f)
 					.clip(RoundedCornerShape(4.dp))
 					.then(
-						if (isCurrent) Modifier.border(
-							BorderStroke(2.dp, MaterialTheme.colorScheme.primary),
-							RoundedCornerShape(4.dp)
-						) else Modifier
+						if (isCurrent) {
+							Modifier.border(
+								BorderStroke(2.dp, MaterialTheme.colorScheme.primary),
+								RoundedCornerShape(4.dp)
+							)
+						} else {
+							Modifier
+						}
 					)
 					.clickable { onTap(path) }
 			) {

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
@@ -32,7 +32,8 @@ class HomeViewModel @Inject constructor(
 		viewModelScope.launch(Dispatchers.IO) {
 			if (stateRepository.state.value.poolPaths.isEmpty()) {
 				val (lastUpdatedMs, currentPath, previousPath) = settingsRepository.loadServiceState()
-				val paths = fileManager.listAll().map { it.absolutePath }
+				val paths = fileManager.listAll()
+					.map { it.absolutePath }
 
 				stateRepository.update {
 					it.copy(
@@ -60,8 +61,18 @@ class HomeViewModel @Inject constructor(
 
 			val state = stateRepository.state.value
 			val newPaths = state.poolPaths - path
-			val newCurrent = if (state.currentWallpaperPath == path) newPaths.firstOrNull() else state.currentWallpaperPath
-			val newPrev = if (state.previousWallpaperPath == path) newPaths.getOrNull(1) else state.previousWallpaperPath
+
+			val newCurrent = if (state.currentWallpaperPath == path) {
+				newPaths.firstOrNull()
+			} else {
+				state.currentWallpaperPath
+			}
+
+			val newPrev = if (state.previousWallpaperPath == path) {
+				newPaths.getOrNull(1)
+			} else {
+				state.previousWallpaperPath
+			}
 
 			stateRepository.update {
 				it.copy(

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
@@ -9,7 +9,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import xyz.attacktive.wallhavend.domain.model.ServiceState
@@ -25,7 +24,7 @@ class HomeViewModel @Inject constructor(
 	private val fileManager: WallpaperFileManager,
 	@param:ApplicationContext private val context: Context
 ): ViewModel() {
-	val serviceState: StateFlow<ServiceState> = stateRepository.state
+	val serviceState = stateRepository.state
 		.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ServiceState())
 
 	init {

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
@@ -15,16 +15,36 @@ import kotlinx.coroutines.launch
 import xyz.attacktive.wallhavend.domain.model.ServiceState
 import xyz.attacktive.wallhavend.domain.repository.ServiceStateRepository
 import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
+import xyz.attacktive.wallhavend.domain.service.WallpaperFileManager
 import xyz.attacktive.wallhavend.domain.service.WallpaperService
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
 	private val stateRepository: ServiceStateRepository,
 	private val settingsRepository: SettingsRepository,
+	private val fileManager: WallpaperFileManager,
 	@param:ApplicationContext private val context: Context
 ): ViewModel() {
 	val serviceState: StateFlow<ServiceState> = stateRepository.state
 		.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ServiceState())
+
+	init {
+		viewModelScope.launch(Dispatchers.IO) {
+			if (stateRepository.state.value.poolPaths.isEmpty()) {
+				val (lastUpdatedMs, currentPath, previousPath) = settingsRepository.loadServiceState()
+				val paths = fileManager.listAll().map { it.absolutePath }
+
+				stateRepository.update {
+					it.copy(
+						poolPaths = paths,
+						lastUpdatedMs = lastUpdatedMs,
+						currentWallpaperPath = currentPath,
+						previousWallpaperPath = previousPath
+					)
+				}
+			}
+		}
+	}
 
 	fun startService() = WallpaperService.start(context)
 	fun stopService() = WallpaperService.stop(context)

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -250,7 +250,12 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 			FilterChip(
 				selected = ratio in selectedRatios,
 				onClick = {
-					val newSet = if (ratio in selectedRatios) selectedRatios - ratio else selectedRatios + ratio
+					val newSet = if (ratio in selectedRatios) {
+						selectedRatios - ratio
+					} else {
+						selectedRatios + ratio
+					}
+
 					aspectRatio = newSet.joinToString(",")
 					onSave(settings.copy(aspectRatio = aspectRatio))
 				},
@@ -397,7 +402,11 @@ private fun AdvancedTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 			)
 
 			Text(
-				text = if (size == 0) "0 — current only, no gallery" else "$size",
+				text = if (size == 0) {
+					"0 — current only, no gallery"
+				} else {
+					"$size"
+				},
 				modifier = Modifier.padding(start = 4.dp)
 			)
 		}

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -243,7 +243,10 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 	Spacer(Modifier.height(16.dp))
 	SectionLabel("ASPECT RATIO")
 
-	val selectedRatios = aspectRatio.split(",").map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+	val selectedRatios = aspectRatio.split(",")
+		.map { it.trim() }
+		.filter { it.isNotEmpty() }
+		.toSet()
 
 	Row(modifier = Modifier.horizontalScroll(rememberScrollState())) {
 		ASPECT_RATIO_SUGGESTIONS.forEach { ratio ->

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -15,7 +14,7 @@ import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(private val settingsRepository: SettingsRepository): ViewModel() {
-	val settings: StateFlow<AppSettings> = settingsRepository.settings
+	val settings = settingsRepository.settings
 		.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppSettings())
 
 	private val _saveError = MutableStateFlow<String?>(null)

--- a/app/src/main/java/xyz/attacktive/wallhavend/util/AppLogger.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/util/AppLogger.kt
@@ -18,6 +18,10 @@ class LogcatLogger : AppLogger {
 	}
 
 	override fun e(tag: String, message: String, throwable: Throwable?) {
-		if (throwable != null) Log.e(tag, message, throwable) else Log.e(tag, message)
+		if (throwable != null) {
+			Log.e(tag, message, throwable)
+		} else {
+			Log.e(tag, message)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Gallery was empty on launch when auto-update was off, because `poolPaths` was only ever populated by the running service
- `HomeViewModel.init` now loads the pool from disk and restores the last-updated timestamp and current/previous wallpaper paths from persisted settings
- `SettingsRepository.loadServiceState()` added to read back the persisted service state

Closes https://github.com/Attacktive/Wallhavend-android/issues/22