### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: ['**']
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: 'Test'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,24 +4,20 @@ on:
     branches: ['main']
   pull_request:
     branches: ['**']
-
 permissions:
-  contents: read
-
+  contents: 'read'
 jobs:
   test:
     name: 'Test'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v4'
-
+        uses: 'actions/checkout@v6'
       - name: 'Set up JDK'
-        uses: 'actions/setup-java@v4'
+        uses: 'actions/setup-java@v5'
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
-
       - name: 'Test'
         run: './gradlew test'


### PR DESCRIPTION
Potential fix for [https://github.com/Attacktive/Wallhavend-android/security/code-scanning/1](https://github.com/Attacktive/Wallhavend-android/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/test.yaml` so the workflow does not rely on repository/organization defaults.  
Best fix here: set workflow-level permissions to the minimum needed:

- `contents: read`

This workflow only checks out code and runs tests, so `contents: read` is sufficient. Place the block at the top level (after `on:` and before `jobs:`) so it applies to all jobs unless overridden later.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
