### PR TITLE
feature: pre-fetch wallpapers to fill pool proactively

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -38,6 +38,7 @@ import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.repository.ServiceStateRepository
 import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
 import xyz.attacktive.wallhavend.domain.repository.WallhavenRepository
+import xyz.attacktive.wallhavend.util.AppLogger
 
 @AndroidEntryPoint
 class WallpaperService: Service() {
@@ -49,9 +50,12 @@ class WallpaperService: Service() {
 	lateinit var fileManager: WallpaperFileManager
 	@Inject
 	lateinit var stateRepository: ServiceStateRepository
+	@Inject
+	lateinit var logger: AppLogger
 
 	private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 	private var timerJob: Job? = null
+	private var prefetchJob: Job? = null
 
 	override fun onBind(intent: Intent?) = null
 
@@ -106,6 +110,8 @@ class WallpaperService: Service() {
 	}
 
 	private suspend fun handleOnlineUpdate(settings: AppSettings) {
+		prefetchJob?.cancel()
+
 		wallhavenRepository.next(settings)
 			.fold(
 				onSuccess = { (_, file) -> onWallpaperFetched(file, settings) },
@@ -139,11 +145,46 @@ class WallpaperService: Service() {
 
 					settingsRepository.saveServiceState(now, paths.firstOrNull(), paths.getOrNull(1))
 					updateNotification()
+					launchPrefetch(settings)
 				},
 				onFailure = { throwable ->
 					postError(AppError.WallpaperApplyFailed(throwable.message ?: "Unknown"))
 				}
 			)
+	}
+
+	private fun launchPrefetch(settings: AppSettings) {
+		prefetchJob = serviceScope.launch {
+			for (i in 0 until settings.poolSize) {
+				logger.debug(TAG, "Pre-fetching wallpaper ${i + 1} of ${settings.poolSize}")
+
+				val currentSettings = settingsRepository.settings.first()
+				if (currentSettings.poolSize == 0) {
+					break
+				}
+
+				val poolCount = fileManager.listAll().size
+				if (poolCount >= currentSettings.poolSize) {
+					break
+				}
+
+				if (!isOnline()) {
+					break
+				}
+
+				if (currentSettings.wifiOnly && !isOnWifi()) {
+					break
+				}
+
+				val result = wallhavenRepository.next(currentSettings)
+				if (result.isFailure) {
+					break
+				}
+
+				val paths = fileManager.listAll().map { it.absolutePath }
+				stateRepository.update { it.copy(poolPaths = paths) }
+			}
+		}
 	}
 
 	private fun onFetchError(throwable: Throwable, settings: AppSettings) {
@@ -316,6 +357,8 @@ class WallpaperService: Service() {
 	}
 
 	companion object {
+		private const val TAG = "WallpaperService"
+
 		const val ACTION_STOP = "xyz.attacktive.wallhavend.STOP"
 		const val ACTION_UPDATE_NOW = "xyz.attacktive.wallhavend.UPDATE_NOW"
 		const val ACTION_APPLY_PATH = "xyz.attacktive.wallhavend.APPLY_PATH"


### PR DESCRIPTION
## Summary

- After a successful wallpaper update, launches a background job to download additional wallpapers up to `poolSize` without applying them
- Cancels any in-progress pre-fetch before starting a regular update, so settings changes mid-fill are handled cleanly
- Respects the `wifiOnly` setting and breaks early if connectivity is lost
- Caps iterations at `poolSize` to prevent semi-infinite loops from duplicate wallpaper results
- Updates `poolPaths` in state after each download so the home screen gallery fills up live

Closes #26

🤖 Generated with [Claude Code](https://claude.ai/code)