### PR TITLE
refactor: move display names into enums

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/Purity.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/Purity.kt
@@ -1,7 +1,7 @@
 package xyz.attacktive.wallhavend.domain.model
 
-enum class Purity(val bitIndex: Int) {
-	SFW(0), SKETCHY(1), NSFW(2)
+enum class Purity(val bitIndex: Int, val displayName: String) {
+	SFW(0, "SFW"), SKETCHY(1, "Sketchy"), NSFW(2, "NSFW")
 }
 
 fun Set<Purity>.toBitString(): String {

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/WallhavenCategory.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/WallhavenCategory.kt
@@ -1,7 +1,7 @@
 package xyz.attacktive.wallhavend.domain.model
 
-enum class WallhavenCategory(val bitIndex: Int) {
-	GENERAL(0), ANIME(1), PEOPLE(2)
+enum class WallhavenCategory(val bitIndex: Int, val displayName: String) {
+	GENERAL(0, "General"), ANIME(1, "Anime"), PEOPLE(2, "People")
 }
 
 fun Set<WallhavenCategory>.toBitString(): String {

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -214,7 +214,7 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 
 					onSave(settings.copy(categories = newSet))
 				},
-				label = { Text(category.name.lowercase().replaceFirstChar { it.uppercase() }) },
+				label = { Text(category.displayName) },
 				modifier = Modifier.padding(end = 8.dp)
 			)
 		}
@@ -240,13 +240,7 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 
 					onSave(settings.copy(purity = newSet))
 				},
-				label = {
-					Text(when (purity) {
-						Purity.SFW -> "SFW"
-						Purity.SKETCHY -> "Sketchy"
-						Purity.NSFW -> "NSFW"
-					})
-				},
+				label = { Text(purity.displayName) },
 				modifier = Modifier.padding(end = 8.dp)
 			)
 		}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,9 +11,11 @@ pluginManagement {
 		gradlePluginPortal()
 	}
 }
+
 plugins {
 	id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
+
 dependencyResolutionManagement {
 	repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 	repositories {


### PR DESCRIPTION
## Summary

- Moves `displayName` properties into `Purity` and `WallhavenCategory` enums so each enum carries its own label
- Updates `SettingsScreen` to read labels directly from enum values instead of mapping them at the call site

🤖 Generated with [Claude Code](https://claude.ai/code)