### PR TITLE
fix: restart service after app update

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
 		<receiver android:name=".domain.service.BootReceiver" android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.BOOT_COMPLETED" />
+				<action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
 			</intent-filter>
 		</receiver>
 	</application>

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/BootReceiver.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/BootReceiver.kt
@@ -16,7 +16,7 @@ class BootReceiver: BroadcastReceiver() {
 	@Inject lateinit var settingsRepository: SettingsRepository
 
 	override fun onReceive(context: Context, intent: Intent) {
-		if (intent.action != Intent.ACTION_BOOT_COMPLETED) {
+		if (intent.action != Intent.ACTION_BOOT_COMPLETED && intent.action != Intent.ACTION_MY_PACKAGE_REPLACED) {
 			return
 		}
 


### PR DESCRIPTION
## Summary

- `BootReceiver` only handled `BOOT_COMPLETED`, so installing an app update killed the foreground service with no mechanism to restart it
- Added `MY_PACKAGE_REPLACED` to the receiver's intent filter and updated `onReceive` to accept both actions
- The existing `autoStartOnBoot` guard applies to both cases — service only restarts if the user had it enabled

🤖 Generated with [Claude Code](https://claude.ai/code)