### PR TITLE
Add color filter setting with multi-select swatch picker

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/data/api/WallhavenApiService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/data/api/WallhavenApiService.kt
@@ -13,6 +13,7 @@ interface WallhavenApiService {
 		@Query(value = "ratios", encoded = true) ratios: String?,
 		@Query("sorting") sorting: String,
 		@Query("seed") seed: String?,
+		@Query("colors") colors: String?,
 		@Query("apikey") apiKey: String?
 	): SearchResponseDto
 }

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
@@ -10,7 +10,8 @@ data class AppSettings(
 	val wifiOnly: Boolean = true,
 	val poolSize: Int = 10,
 	val apiKey: String = "",
-	val autoStartOnBoot: Boolean = true
+	val autoStartOnBoot: Boolean = true,
+	val filterColor: String = ""
 )
 
 val UPDATE_INTERVAL_OPTIONS = listOf(1, 5, 15, 30, 60, 180, 360, 1440)

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -31,6 +31,7 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 		val POOL_SIZE = intPreferencesKey("pool_size")
 		val API_KEY = stringPreferencesKey("api_key")
 		val AUTO_START_ON_BOOT = booleanPreferencesKey("auto_start_on_boot")
+		val FILTER_COLOR = stringPreferencesKey("filter_color")
 		val LAST_UPDATED_MS = longPreferencesKey("last_updated_ms")
 		val CURRENT_WALLPAPER_PATH = stringPreferencesKey("current_wallpaper_path")
 		val PREVIOUS_WALLPAPER_PATH = stringPreferencesKey("previous_wallpaper_path")
@@ -55,7 +56,8 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 				wifiOnly = preferences[Keys.WIFI_ONLY] ?: true,
 				poolSize = preferences[Keys.POOL_SIZE] ?: 10,
 				apiKey = preferences[Keys.API_KEY] ?: "",
-				autoStartOnBoot = preferences[Keys.AUTO_START_ON_BOOT] ?: true
+				autoStartOnBoot = preferences[Keys.AUTO_START_ON_BOOT] ?: true,
+				filterColor = preferences[Keys.FILTER_COLOR] ?: ""
 			)
 			.also { logger.debug(TAG, "read: ${it.redactedForLog()}") }
 		}
@@ -80,6 +82,7 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 			preferences[Keys.POOL_SIZE] = settings.poolSize
 			preferences[Keys.API_KEY] = settings.apiKey
 			preferences[Keys.AUTO_START_ON_BOOT] = settings.autoStartOnBoot
+			preferences[Keys.FILTER_COLOR] = settings.filterColor
 		}
 
 		logger.debug(TAG, "save() completed")

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
@@ -22,6 +22,7 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 		val categories: String,
 		val purity: String,
 		val ratios: String?,
+		val colors: String?,
 		val apiKey: String?
 	)
 
@@ -30,6 +31,7 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 		categories = categories.toBitString(),
 		purity = purity.toBitString(),
 		ratios = aspectRatio.ifBlank { null },
+		colors = filterColor.ifBlank { null },
 		apiKey = apiKey.ifBlank { null }
 	)
 
@@ -69,6 +71,7 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 				.shuffled()
 				.take(6)
 				.joinToString(""),
+			colors = key.colors,
 			apiKey = key.apiKey
 		)
 

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -1,20 +1,28 @@
 package xyz.attacktive.wallhavend.ui.settings
 
 import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
@@ -45,7 +53,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
@@ -55,6 +65,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.core.graphics.toColorInt
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import xyz.attacktive.wallhavend.R
@@ -171,8 +182,10 @@ fun SettingsScreen(
 private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 	var searchQuery by rememberSaveable { mutableStateOf(settings.searchQuery) }
 	var aspectRatio by rememberSaveable { mutableStateOf(settings.aspectRatio) }
+	var filterColor by rememberSaveable { mutableStateOf(settings.filterColor) }
 	var searchQueryHasFocused by remember { mutableStateOf(false) }
 	var aspectRatioHasFocused by remember { mutableStateOf(false) }
+	var filterColorHasFocused by remember { mutableStateOf(false) }
 
 	LaunchedEffect(settings.searchQuery) {
 		if (searchQuery != settings.searchQuery) {
@@ -183,6 +196,12 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 	LaunchedEffect(settings.aspectRatio) {
 		if (aspectRatio != settings.aspectRatio) {
 			aspectRatio = settings.aspectRatio
+		}
+	}
+
+	LaunchedEffect(settings.filterColor) {
+		if (filterColor != settings.filterColor) {
+			filterColor = settings.filterColor
 		}
 	}
 
@@ -299,6 +318,48 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 
 	Text(
 		text = stringResource(R.string.settings_hint_aspect_ratio),
+		style = MaterialTheme.typography.bodySmall,
+		color = MaterialTheme.colorScheme.onSurfaceVariant,
+		modifier = Modifier.padding(top = 4.dp)
+	)
+
+	Spacer(Modifier.height(16.dp))
+	SectionLabel(stringResource(R.string.settings_label_filter_color))
+	ColorSwatchPicker(
+		selected = filterColor,
+		onSelect = { newColor ->
+			filterColor = newColor
+			onSave(settings.copy(filterColor = newColor))
+		}
+	)
+
+	OutlinedTextField(
+		value = filterColor,
+		onValueChange = { filterColor = it.replace("#", "") },
+		placeholder = { Text(stringResource(R.string.settings_placeholder_filter_color)) },
+		trailingIcon = {
+			if (filterColor.isNotEmpty()) {
+				IconButton(onClick = {
+					filterColor = ""
+					onSave(settings.copy(filterColor = ""))
+				}) {
+					Icon(Icons.Filled.Clear, contentDescription = null)
+				}
+			}
+		},
+		singleLine = true,
+		modifier = Modifier
+			.fillMaxWidth()
+			.onFocusChanged { focusState ->
+				when {
+					focusState.isFocused -> filterColorHasFocused = true
+					filterColorHasFocused -> onSave(settings.copy(filterColor = filterColor))
+				}
+			}
+	)
+
+	Text(
+		text = stringResource(R.string.settings_hint_filter_color),
 		style = MaterialTheme.typography.bodySmall,
 		color = MaterialTheme.colorScheme.onSurfaceVariant,
 		modifier = Modifier.padding(top = 4.dp)
@@ -471,6 +532,67 @@ private fun SectionLabel(text: String) {
 		color = MaterialTheme.colorScheme.onSurfaceVariant,
 		modifier = Modifier.padding(bottom = 4.dp)
 	)
+}
+
+@Composable
+private fun ColorSwatchPicker(selected: String, onSelect: (String) -> Unit) {
+	val swatches = listOf(
+		"660000", "990000", "cc0000", "cc3333", "ea4c88", "993399", "663399",
+		"333399", "0066cc", "0099cc", "66cccc", "77cc33", "669900", "336600",
+		"666600", "999900", "cccc33", "ffff00", "ffcc33", "ff9900", "ff6600",
+		"cc6633", "996633", "663300", "000000", "999999", "cccccc", "ffffff", "424153"
+	)
+
+	val selectedSet = selected.split(",")
+		.map { it.trim().lowercase() }
+		.filter { it.isNotEmpty() }
+		.toSet()
+
+	FlowRow(
+		modifier = Modifier
+			.fillMaxWidth()
+			.padding(vertical = 4.dp)
+	) {
+		swatches.forEach { hex ->
+			val argb = "#$hex".toColorInt()
+			val isSelected = hex in selectedSet
+			val luminance = (0.299f * android.graphics.Color.red(argb) +
+				0.587f * android.graphics.Color.green(argb) +
+				0.114f * android.graphics.Color.blue(argb)) / 255f
+
+			Box(
+				contentAlignment = Alignment.Center,
+				modifier = Modifier
+					.padding(2.dp)
+					.size(32.dp)
+					.clip(CircleShape)
+					.background(Color(argb))
+					.border(
+						width = if (isSelected) 2.dp else 0.5.dp,
+						color = if (isSelected) MaterialTheme.colorScheme.primary else Color.Gray.copy(alpha = 0.4f),
+						shape = CircleShape
+					)
+					.clickable {
+						val newSet = if (isSelected) {
+							selectedSet - hex
+						} else {
+							selectedSet + hex
+						}
+
+						onSelect(newSet.joinToString(","))
+					}
+			) {
+				if (isSelected) {
+					Icon(
+						imageVector = Icons.Filled.Check,
+						contentDescription = null,
+						tint = if (luminance > 0.5f) Color.Black else Color.White,
+						modifier = Modifier.size(18.dp)
+					)
+				}
+			}
+		}
+	}
 }
 
 @Composable

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -20,6 +20,9 @@
 	<string name="settings_label_aspect_ratio">SEITENVERHÄLTNIS</string>
 	<string name="settings_hint_aspect_ratio">Leer lassen, um das Filtern nach Verhältnis zu überspringen</string>
 	<string name="settings_placeholder_aspect_ratio">Benutzerdefiniert, z.B. 9x16 oder 9x16,16x9</string>
+	<string name="settings_label_filter_color">FARBFILTER (OPTIONAL)</string>
+	<string name="settings_hint_filter_color">Leer lassen, um das Filtern nach Farbe zu überspringen</string>
+	<string name="settings_placeholder_filter_color">z.B. ff0000 oder ff0000,0066cc</string>
 	<string name="settings_label_update_interval">AKTUALISIERUNGSINTERVALL</string>
 	<string name="settings_label_wallpaper_target">HINTERGRUND-ZIEL</string>
 	<string name="settings_hint_wallpaper_target">Sperrbildschirm funktioniert auf einigen Geräten eventuell nicht (z.B. Samsung One UI)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -20,6 +20,9 @@
 	<string name="settings_label_aspect_ratio">RELACIÓN DE ASPECTO</string>
 	<string name="settings_hint_aspect_ratio">Dejar en blanco para omitir el filtrado por relación</string>
 	<string name="settings_placeholder_aspect_ratio">Personalizado, ej. 9x16 o 9x16,16x9</string>
+	<string name="settings_label_filter_color">FILTRO DE COLOR (OPCIONAL)</string>
+	<string name="settings_hint_filter_color">Dejar en blanco para omitir el filtrado por color</string>
+	<string name="settings_placeholder_filter_color">ej. ff0000 o ff0000,0066cc</string>
 	<string name="settings_label_update_interval">INTERVALO DE ACTUALIZACIÓN</string>
 	<string name="settings_label_wallpaper_target">DESTINO DEL FONDO DE PANTALLA</string>
 	<string name="settings_hint_wallpaper_target">La pantalla de bloqueo puede no funcionar en algunos dispositivos (ej. Samsung One UI)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -20,6 +20,9 @@
 	<string name="settings_label_aspect_ratio">RATIO D\'ASPECT</string>
 	<string name="settings_hint_aspect_ratio">Laisser vide pour ignorer le filtrage par ratio</string>
 	<string name="settings_placeholder_aspect_ratio">Personnalisé, ex: 9x16 ou 9x16,16x9</string>
+	<string name="settings_label_filter_color">FILTRE COULEUR (OPTIONNEL)</string>
+	<string name="settings_hint_filter_color">Laisser vide pour ignorer le filtre couleur</string>
+	<string name="settings_placeholder_filter_color">ex: ff0000 ou ff0000,0066cc</string>
 	<string name="settings_label_update_interval">INTERVALLE DE MISE À JOUR</string>
 	<string name="settings_label_wallpaper_target">CIBLE DU FOND D\'ÉCRAN</string>
 	<string name="settings_hint_wallpaper_target">L\'écran de verrouillage peut ne pas fonctionner sur certains appareils (ex: Samsung One UI)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -20,6 +20,9 @@
 	<string name="settings_label_aspect_ratio">アスペクト比</string>
 	<string name="settings_hint_aspect_ratio">比率によるフィルタリングをスキップするには空欄にします</string>
 	<string name="settings_placeholder_aspect_ratio">カスタム 例: 9x16 または 9x16,16x9</string>
+	<string name="settings_label_filter_color">カラーフィルター (任意)</string>
+	<string name="settings_hint_filter_color">カラーフィルタリングをスキップするには空欄にします</string>
+	<string name="settings_placeholder_filter_color">例: ff0000 または ff0000,0066cc</string>
 	<string name="settings_label_update_interval">更新間隔</string>
 	<string name="settings_label_wallpaper_target">壁紙の対象</string>
 	<string name="settings_hint_wallpaper_target">ロック画面は一部のデバイス (例: Samsung One UI) では動作しない場合があります</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -20,6 +20,9 @@
 	<string name="settings_label_aspect_ratio">화면 비율</string>
 	<string name="settings_hint_aspect_ratio">비율 필터링을 건너뛰려면 비워 두세요</string>
 	<string name="settings_placeholder_aspect_ratio">사용자 지정 예: 9x16 또는 9x16,16x9</string>
+	<string name="settings_label_filter_color">색상 필터 (선택 사항)</string>
+	<string name="settings_hint_filter_color">색상 필터링을 건너뛰려면 비워 두세요</string>
+	<string name="settings_placeholder_filter_color">예: ff0000 또는 ff0000,0066cc</string>
 	<string name="settings_label_update_interval">업데이트 간격</string>
 	<string name="settings_label_wallpaper_target">배경화면 대상</string>
 	<string name="settings_hint_wallpaper_target">잠금 화면은 일부 기기(예: Samsung One UI)에서 작동하지 않을 수 있습니다</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -20,6 +20,9 @@
 	<string name="settings_label_aspect_ratio">PROPORÇÃO DE TELA</string>
 	<string name="settings_hint_aspect_ratio">Deixe em branco para ignorar a filtragem por proporção</string>
 	<string name="settings_placeholder_aspect_ratio">Personalizado, ex: 9x16 ou 9x16,16x9</string>
+	<string name="settings_label_filter_color">FILTRO DE COR (OPCIONAL)</string>
+	<string name="settings_hint_filter_color">Deixe em branco para ignorar a filtragem por cor</string>
+	<string name="settings_placeholder_filter_color">ex: ff0000 ou ff0000,0066cc</string>
 	<string name="settings_label_update_interval">INTERVALO DE ATUALIZAÇÃO</string>
 	<string name="settings_label_wallpaper_target">DESTINO DO PAPEL DE PAREDE</string>
 	<string name="settings_hint_wallpaper_target">A tela de bloqueio pode não funcionar em alguns dispositivos (ex: Samsung One UI)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -20,6 +20,9 @@
 	<string name="settings_label_aspect_ratio">宽高比</string>
 	<string name="settings_hint_aspect_ratio">留空以跳过比例过滤</string>
 	<string name="settings_placeholder_aspect_ratio">自定义，例如：9x16 或 9x16,16x9</string>
+	<string name="settings_label_filter_color">颜色筛选（可选）</string>
+	<string name="settings_hint_filter_color">留空以跳过颜色筛选</string>
+	<string name="settings_placeholder_filter_color">例如：ff0000 或 ff0000,0066cc</string>
 	<string name="settings_label_update_interval">更新间隔</string>
 	<string name="settings_label_wallpaper_target">壁纸应用范围</string>
 	<string name="settings_hint_wallpaper_target">锁屏壁纸在某些设备（如三星 One UI）上可能无法生效</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,9 @@
 	<string name="settings_label_aspect_ratio">ASPECT RATIO</string>
 	<string name="settings_hint_aspect_ratio">Leave blank to skip ratio filtering</string>
 	<string name="settings_placeholder_aspect_ratio">Custom, e.g. 9x16 or 9x16,16x9</string>
+	<string name="settings_label_filter_color">COLOR FILTER (OPTIONAL)</string>
+	<string name="settings_hint_filter_color">Leave blank to skip color filtering</string>
+	<string name="settings_placeholder_filter_color">e.g. ff0000 or ff0000,0066cc</string>
 	<string name="settings_label_update_interval">UPDATE INTERVAL</string>
 	<string name="settings_label_wallpaper_target">WALLPAPER TARGET</string>
 	<string name="settings_hint_wallpaper_target">Lock screen may not work on some devices (e.g. Samsung One UI)</string>

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
@@ -40,7 +40,7 @@ class WallhavenRepositoryTest {
 
 	@Test
 	fun `next fetches from API and returns first result`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
 		coEvery { fileManager.download(any()) } answers {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
@@ -49,12 +49,12 @@ class WallhavenRepositoryTest {
 		assertTrue(result.isSuccess)
 		assertEquals("w1", result.getOrNull()?.first?.id)
 
-		coVerify(exactly = 1) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 1) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 
 	@Test
 	fun `next reuses cache on second call`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
 		coEvery { fileManager.download(any()) } answers {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
@@ -62,12 +62,12 @@ class WallhavenRepositoryTest {
 		repository.next(AppSettings())
 		repository.next(AppSettings())
 
-		coVerify(exactly = 1) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 1) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 
 	@Test
 	fun `cache invalidates when query changes`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
 		coEvery { fileManager.download(any()) } answers {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
@@ -75,12 +75,25 @@ class WallhavenRepositoryTest {
 		repository.next(AppSettings(searchQuery = "mountains"))
 		repository.next(AppSettings(searchQuery = "ocean"))
 
-		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `cache invalidates when filterColor changes`() = runTest {
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		repository.next(AppSettings(filterColor = "cc0000"))
+		repository.next(AppSettings(filterColor = "0066cc"))
+
+		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 
 	@Test
 	fun `returns NoResultsException when API returns empty list`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any()) } returns makePage(0)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(0)
 
 		val result = repository.next(AppSettings())
 		assertTrue(result.isFailure)


### PR DESCRIPTION
Closes #25 (partially — color filter only).

## Summary

- Adds `filterColor: String` to `AppSettings`, persisted via DataStore
- Wires `colors=` query parameter through `WallhavenApiService` and `WallhavenRepository` (included in cache key)
- UI: grid of 29 preset color swatches in the Content tab, matching Wallhaven's own palette
- Multi-select confirmed working via curl — the API accepts comma-separated hex values as an OR filter (e.g. `cc0000,0066cc` returns the union of both)
- Text field below swatches for free-form input; trailing clear button resets everything at once
- String resources updated in all 8 locales

## Key files

- https://github.com/Attacktive/Wallhavend-android/blob/15cfa1c4e6aa455ea18bc54ce3185d19c26bc509/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt#L527-L590
- https://github.com/Attacktive/Wallhavend-android/blob/15cfa1c4e6aa455ea18bc54ce3185d19c26bc509/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt#L20-L35

🤖 Generated with [Claude Code](https://claude.ai/code)