### PR TITLE
Auto-detect aspect ratio from screen dimensions

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
@@ -1,5 +1,6 @@
 package xyz.attacktive.wallhavend.domain.model
 
+import kotlin.math.abs
 import xyz.attacktive.wallhavend.domain.model.query.Category
 import xyz.attacktive.wallhavend.domain.model.query.Purity
 import xyz.attacktive.wallhavend.domain.model.query.Sorting
@@ -9,7 +10,6 @@ data class AppSettings(
 	val searchQuery: String = "",
 	val categories: Set<Category> = setOf(Category.GENERAL),
 	val purity: Set<Purity> = setOf(Purity.SFW),
-	val aspectRatio: String = "",
 	val updateIntervalMinutes: Int = 60,
 	val wallpaperTarget: WallpaperTarget = WallpaperTarget.HOME,
 	val wifiOnly: Boolean = true,
@@ -23,4 +23,18 @@ data class AppSettings(
 
 val UPDATE_INTERVAL_OPTIONS = listOf(1, 5, 15, 30, 60, 180, 360, 1440)
 val POOL_SIZE_OPTIONS = listOf(0, 5, 10, 25, 50)
-val ASPECT_RATIO_SUGGESTIONS = listOf("9x16", "10x16", "16x9", "16x10", "21x9", "4x3", "1x1")
+
+/**
+ * Ratios with meaningful content on Wallhaven (verified by querying meta.total per ratio).
+ * Sparse ratios like 9x18/9x19/9x20 are intentionally excluded; modern tall phones fall back to 9x16.
+ */
+private val ASPECT_RATIO_CANDIDATES = listOf("9x16", "10x16", "3x4", "16x9", "16x10", "4x3", "21x9", "1x1")
+
+fun closestAspectRatio(width: Int, height: Int): String {
+	val actual = width.toFloat() / height
+
+	return ASPECT_RATIO_CANDIDATES.minBy { candidate ->
+		val (w, h) = candidate.split("x").map { it.toFloat() }
+		abs(w / h - actual)
+	}
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -26,7 +26,6 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 		val SEARCH_QUERY = stringPreferencesKey("search_query")
 		val CATEGORIES = stringSetPreferencesKey("categories")
 		val PURITY = stringSetPreferencesKey("purity")
-		val ASPECT_RATIO = stringPreferencesKey("aspect_ratio")
 		val UPDATE_INTERVAL_MINUTES = intPreferencesKey("update_interval_minutes")
 		val WALLPAPER_TARGET = stringPreferencesKey("wallpaper_target")
 		val WIFI_ONLY = booleanPreferencesKey("wifi_only")
@@ -52,7 +51,6 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 					.mapNotNull { runCatching { Purity.valueOf(it) }.getOrNull() }
 					.toSet()
 					.ifEmpty { setOf(Purity.SFW) },
-				aspectRatio = preferences[Keys.ASPECT_RATIO] ?: "",
 				updateIntervalMinutes = preferences[Keys.UPDATE_INTERVAL_MINUTES] ?: 60,
 				wallpaperTarget = preferences[Keys.WALLPAPER_TARGET]
 					?.let { runCatching { WallpaperTarget.valueOf(it) }.getOrNull() }
@@ -81,7 +79,6 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 				.map { it.name }
 				.toSet()
 
-			preferences[Keys.ASPECT_RATIO] = settings.aspectRatio
 			preferences[Keys.UPDATE_INTERVAL_MINUTES] = settings.updateIntervalMinutes
 			preferences[Keys.WALLPAPER_TARGET] = settings.wallpaperTarget.name
 			preferences[Keys.WIFI_ONLY] = settings.wifiOnly

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
@@ -34,11 +34,11 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 		val toplistRange: String?
 	)
 
-	private fun AppSettings.toSearchKey() = SearchKey(
+	private fun AppSettings.toSearchKey(aspectRatio: String) = SearchKey(
 		query = searchQuery.ifBlank { null },
 		categories = categories.toBitString(),
 		purity = purity.toBitString(),
-		ratios = aspectRatio.ifBlank { null },
+		ratios = aspectRatio,
 		colors = filterColor.ifBlank { null },
 		apiKey = apiKey.ifBlank { null },
 		sorting = sorting,
@@ -49,8 +49,8 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 		}
 	)
 
-	suspend fun next(settings: AppSettings): Result<Pair<Wallpaper, File>> = mutex.withLock {
-		val key = settings.toSearchKey()
+	suspend fun next(settings: AppSettings, aspectRatio: String): Result<Pair<Wallpaper, File>> = mutex.withLock {
+		val key = settings.toSearchKey(aspectRatio)
 		if (key != cacheKey) {
 			cache.clear()
 			cacheKey = key

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -15,6 +15,9 @@ import android.content.Intent
 import android.graphics.BitmapFactory
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import android.os.Build
+import android.util.DisplayMetrics
+import android.view.WindowManager
 import androidx.core.app.NotificationCompat
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -32,6 +35,7 @@ import xyz.attacktive.wallhavend.WallhavendApplication.Companion.NOTIFICATION_CH
 import xyz.attacktive.wallhavend.WallhavendApplication.Companion.NOTIFICATION_ID
 import xyz.attacktive.wallhavend.domain.model.AppError
 import xyz.attacktive.wallhavend.domain.model.AppSettings
+import xyz.attacktive.wallhavend.domain.model.closestAspectRatio
 import xyz.attacktive.wallhavend.domain.model.NoResultsException
 import xyz.attacktive.wallhavend.domain.model.UnsupportedFormatException
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
@@ -106,7 +110,7 @@ class WallpaperService: Service() {
 	}
 
 	private suspend fun handleOnlineUpdate(settings: AppSettings) {
-		wallhavenRepository.next(settings)
+		wallhavenRepository.next(settings, screenAspectRatio())
 			.fold(
 				onSuccess = { (_, file) -> onWallpaperFetched(file, settings) },
 				onFailure = { throwable -> onFetchError(throwable, settings) }
@@ -149,7 +153,7 @@ class WallpaperService: Service() {
 	private fun onFetchError(throwable: Throwable, settings: AppSettings) {
 		val error = when (throwable) {
 			// Wallhaven server bug: certain ratios yield zero results when an API key is present
-			is NoResultsException -> if (settings.apiKey.isNotBlank() && settings.aspectRatio.isNotBlank()) {
+			is NoResultsException -> if (settings.apiKey.isNotBlank()) {
 				AppError.NoResultsWithRatioHint
 			} else {
 				AppError.NoResults
@@ -243,6 +247,27 @@ class WallpaperService: Service() {
 			delay(10_000)
 			stateRepository.update { it.copy(error = null) }
 		}
+	}
+
+	private fun screenAspectRatio(): String {
+		val windowManager = getSystemService(WindowManager::class.java)
+
+		val (width, height) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+			val bounds = windowManager.currentWindowMetrics.bounds
+			bounds.width() to bounds.height()
+		} else {
+			legacyScreenDimensions(windowManager)
+		}
+
+		return closestAspectRatio(width, height)
+	}
+
+	@Suppress("DEPRECATION")
+	private fun legacyScreenDimensions(windowManager: WindowManager): Pair<Int, Int> {
+		val displayMetrics = DisplayMetrics()
+		windowManager.defaultDisplay.getRealMetrics(displayMetrics)
+
+		return displayMetrics.widthPixels to displayMetrics.heightPixels
 	}
 
 	private fun isOnline(): Boolean {

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -72,7 +71,6 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
 import xyz.attacktive.wallhavend.R
-import xyz.attacktive.wallhavend.domain.model.ASPECT_RATIO_SUGGESTIONS
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.POOL_SIZE_OPTIONS
 import xyz.attacktive.wallhavend.domain.model.query.Purity
@@ -186,18 +184,11 @@ fun SettingsScreen(
 @Composable
 private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 	var searchQuery by rememberSaveable { mutableStateOf(settings.searchQuery) }
-	var aspectRatio by rememberSaveable { mutableStateOf(settings.aspectRatio) }
 	var filterColor by rememberSaveable { mutableStateOf(settings.filterColor) }
 
 	LaunchedEffect(settings.searchQuery) {
 		if (searchQuery != settings.searchQuery) {
 			searchQuery = settings.searchQuery
-		}
-	}
-
-	LaunchedEffect(settings.aspectRatio) {
-		if (aspectRatio != settings.aspectRatio) {
-			aspectRatio = settings.aspectRatio
 		}
 	}
 
@@ -211,12 +202,6 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 		value = searchQuery,
 		upstream = settings.searchQuery,
 		onPersist = { onSave(settings.copy(searchQuery = it)) }
-	)
-
-	PersistOnChange(
-		value = aspectRatio,
-		upstream = settings.aspectRatio,
-		onPersist = { onSave(settings.copy(aspectRatio = it)) }
 	)
 
 	PersistOnChange(
@@ -285,49 +270,6 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 			)
 		}
 	}
-
-	Spacer(Modifier.height(16.dp))
-	SectionLabel(stringResource(R.string.settings_label_aspect_ratio))
-
-	val selectedRatios = aspectRatio.split(",")
-		.map { it.trim() }
-		.filter { it.isNotEmpty() }
-		.toSet()
-
-	Row(modifier = Modifier.horizontalScroll(rememberScrollState())) {
-		ASPECT_RATIO_SUGGESTIONS.forEach { ratio ->
-			FilterChip(
-				selected = ratio in selectedRatios,
-				onClick = {
-					val newSet = if (ratio in selectedRatios) {
-						selectedRatios - ratio
-					} else {
-						selectedRatios + ratio
-					}
-
-					aspectRatio = newSet.joinToString(",")
-					onSave(settings.copy(aspectRatio = aspectRatio))
-				},
-				label = { Text(ratio) },
-				modifier = Modifier.padding(end = 8.dp)
-			)
-		}
-	}
-
-	OutlinedTextField(
-		value = aspectRatio,
-		onValueChange = { aspectRatio = it },
-		placeholder = { Text(stringResource(R.string.settings_placeholder_aspect_ratio)) },
-		singleLine = true,
-		modifier = Modifier.fillMaxWidth()
-	)
-
-	Text(
-		text = stringResource(R.string.settings_hint_aspect_ratio),
-		style = MaterialTheme.typography.bodySmall,
-		color = MaterialTheme.colorScheme.onSurfaceVariant,
-		modifier = Modifier.padding(top = 4.dp)
-	)
 
 	Spacer(Modifier.height(16.dp))
 	SectionLabel(stringResource(R.string.settings_label_filter_color))

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -16,11 +16,7 @@
 	<string name="settings_label_search_query">SUCHANFRAGE (OPTIONAL)</string>
 	<string name="settings_placeholder_search_query">z.B. landscape mountains</string>
 	<string name="settings_label_categories">KATEGORIEN</string>
-	<string name="settings_label_content_rating">CONTENT-RATING</string>
-	<string name="settings_label_aspect_ratio">SEITENVERHÄLTNIS</string>
-	<string name="settings_hint_aspect_ratio">Leer lassen, um das Filtern nach Verhältnis zu überspringen</string>
-	<string name="settings_placeholder_aspect_ratio">Benutzerdefiniert, z.B. 9x16 oder 9x16,16x9</string>
-	<string name="settings_label_filter_color">FARBFILTER (OPTIONAL)</string>
+	<string name="settings_label_content_rating">CONTENT-RATING</string>	<string name="settings_label_filter_color">FARBFILTER (OPTIONAL)</string>
 	<string name="settings_hint_filter_color">Leer lassen, um das Filtern nach Farbe zu überspringen</string>
 	<string name="settings_placeholder_filter_color">z.B. ff0000 oder ff0000,0066cc</string>
 	<string name="settings_label_update_interval">AKTUALISIERUNGSINTERVALL</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -16,11 +16,7 @@
 	<string name="settings_label_search_query">CONSULTA DE BÚSQUEDA (OPCIONAL)</string>
 	<string name="settings_placeholder_search_query">ej. landscape mountains</string>
 	<string name="settings_label_categories">CATEGORÍAS</string>
-	<string name="settings_label_content_rating">CLASIFICACIÓN DE CONTENIDO</string>
-	<string name="settings_label_aspect_ratio">RELACIÓN DE ASPECTO</string>
-	<string name="settings_hint_aspect_ratio">Dejar en blanco para omitir el filtrado por relación</string>
-	<string name="settings_placeholder_aspect_ratio">Personalizado, ej. 9x16 o 9x16,16x9</string>
-	<string name="settings_label_filter_color">FILTRO DE COLOR (OPCIONAL)</string>
+	<string name="settings_label_content_rating">CLASIFICACIÓN DE CONTENIDO</string>	<string name="settings_label_filter_color">FILTRO DE COLOR (OPCIONAL)</string>
 	<string name="settings_hint_filter_color">Dejar en blanco para omitir el filtrado por color</string>
 	<string name="settings_placeholder_filter_color">ej. ff0000 o ff0000,0066cc</string>
 	<string name="settings_label_update_interval">INTERVALO DE ACTUALIZACIÓN</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -16,11 +16,7 @@
 	<string name="settings_label_search_query">RECHERCHE (OPTIONNEL)</string>
 	<string name="settings_placeholder_search_query">ex: landscape mountains</string>
 	<string name="settings_label_categories">CATÉGORIES</string>
-	<string name="settings_label_content_rating">CLASSEMENT DU CONTENU</string>
-	<string name="settings_label_aspect_ratio">RATIO D\'ASPECT</string>
-	<string name="settings_hint_aspect_ratio">Laisser vide pour ignorer le filtrage par ratio</string>
-	<string name="settings_placeholder_aspect_ratio">Personnalisé, ex: 9x16 ou 9x16,16x9</string>
-	<string name="settings_label_filter_color">FILTRE COULEUR (OPTIONNEL)</string>
+	<string name="settings_label_content_rating">CLASSEMENT DU CONTENU</string>	<string name="settings_label_filter_color">FILTRE COULEUR (OPTIONNEL)</string>
 	<string name="settings_hint_filter_color">Laisser vide pour ignorer le filtre couleur</string>
 	<string name="settings_placeholder_filter_color">ex: ff0000 ou ff0000,0066cc</string>
 	<string name="settings_label_update_interval">INTERVALLE DE MISE À JOUR</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -16,11 +16,7 @@
 	<string name="settings_label_search_query">検索クエリ (任意)</string>
 	<string name="settings_placeholder_search_query">例: landscape mountains</string>
 	<string name="settings_label_categories">カテゴリ</string>
-	<string name="settings_label_content_rating">コンテンツ評価</string>
-	<string name="settings_label_aspect_ratio">アスペクト比</string>
-	<string name="settings_hint_aspect_ratio">比率によるフィルタリングをスキップするには空欄にします</string>
-	<string name="settings_placeholder_aspect_ratio">カスタム 例: 9x16 または 9x16,16x9</string>
-	<string name="settings_label_filter_color">カラーフィルター (任意)</string>
+	<string name="settings_label_content_rating">コンテンツ評価</string>	<string name="settings_label_filter_color">カラーフィルター (任意)</string>
 	<string name="settings_hint_filter_color">カラーフィルタリングをスキップするには空欄にします</string>
 	<string name="settings_placeholder_filter_color">例: ff0000 または ff0000,0066cc</string>
 	<string name="settings_label_update_interval">更新間隔</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -16,11 +16,7 @@
 	<string name="settings_label_search_query">검색어 (선택 사항)</string>
 	<string name="settings_placeholder_search_query">예: landscape mountains</string>
 	<string name="settings_label_categories">카테고리</string>
-	<string name="settings_label_content_rating">콘텐츠 등급</string>
-	<string name="settings_label_aspect_ratio">화면 비율</string>
-	<string name="settings_hint_aspect_ratio">비율 필터링을 건너뛰려면 비워 두세요</string>
-	<string name="settings_placeholder_aspect_ratio">사용자 지정 예: 9x16 또는 9x16,16x9</string>
-	<string name="settings_label_filter_color">색상 필터 (선택 사항)</string>
+	<string name="settings_label_content_rating">콘텐츠 등급</string>	<string name="settings_label_filter_color">색상 필터 (선택 사항)</string>
 	<string name="settings_hint_filter_color">색상 필터링을 건너뛰려면 비워 두세요</string>
 	<string name="settings_placeholder_filter_color">예: ff0000 또는 ff0000,0066cc</string>
 	<string name="settings_label_update_interval">업데이트 간격</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -16,11 +16,7 @@
 	<string name="settings_label_search_query">TERMO DE BUSCA (OPCIONAL)</string>
 	<string name="settings_placeholder_search_query">ex: landscape mountains</string>
 	<string name="settings_label_categories">CATEGORIAS</string>
-	<string name="settings_label_content_rating">CLASSIFICAÇÃO DE CONTEÚDO</string>
-	<string name="settings_label_aspect_ratio">PROPORÇÃO DE TELA</string>
-	<string name="settings_hint_aspect_ratio">Deixe em branco para ignorar a filtragem por proporção</string>
-	<string name="settings_placeholder_aspect_ratio">Personalizado, ex: 9x16 ou 9x16,16x9</string>
-	<string name="settings_label_filter_color">FILTRO DE COR (OPCIONAL)</string>
+	<string name="settings_label_content_rating">CLASSIFICAÇÃO DE CONTEÚDO</string>	<string name="settings_label_filter_color">FILTRO DE COR (OPCIONAL)</string>
 	<string name="settings_hint_filter_color">Deixe em branco para ignorar a filtragem por cor</string>
 	<string name="settings_placeholder_filter_color">ex: ff0000 ou ff0000,0066cc</string>
 	<string name="settings_label_update_interval">INTERVALO DE ATUALIZAÇÃO</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -16,11 +16,7 @@
 	<string name="settings_label_search_query">搜索内容 (可选)</string>
 	<string name="settings_placeholder_search_query">例如：landscape mountains</string>
 	<string name="settings_label_categories">分类</string>
-	<string name="settings_label_content_rating">内容分级</string>
-	<string name="settings_label_aspect_ratio">宽高比</string>
-	<string name="settings_hint_aspect_ratio">留空以跳过比例过滤</string>
-	<string name="settings_placeholder_aspect_ratio">自定义，例如：9x16 或 9x16,16x9</string>
-	<string name="settings_label_filter_color">颜色筛选（可选）</string>
+	<string name="settings_label_content_rating">内容分级</string>	<string name="settings_label_filter_color">颜色筛选（可选）</string>
 	<string name="settings_hint_filter_color">留空以跳过颜色筛选</string>
 	<string name="settings_placeholder_filter_color">例如：ff0000 或 ff0000,0066cc</string>
 	<string name="settings_label_update_interval">更新间隔</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,11 +16,7 @@
 	<string name="settings_label_search_query">SEARCH QUERY (OPTIONAL)</string>
 	<string name="settings_placeholder_search_query">e.g. landscape mountains</string>
 	<string name="settings_label_categories">CATEGORIES</string>
-	<string name="settings_label_content_rating">CONTENT RATING</string>
-	<string name="settings_label_aspect_ratio">ASPECT RATIO</string>
-	<string name="settings_hint_aspect_ratio">Leave blank to skip ratio filtering</string>
-	<string name="settings_placeholder_aspect_ratio">Custom, e.g. 9x16 or 9x16,16x9</string>
-	<string name="settings_label_filter_color">COLOR FILTER (OPTIONAL)</string>
+	<string name="settings_label_content_rating">CONTENT RATING</string>	<string name="settings_label_filter_color">COLOR FILTER (OPTIONAL)</string>
 	<string name="settings_hint_filter_color">Leave blank to skip color filtering</string>
 	<string name="settings_placeholder_filter_color">e.g. ff0000 or ff0000,0066cc</string>
 	<string name="settings_label_sorting">SORTING</string>

--- a/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
@@ -70,7 +70,6 @@ class SettingsRepositoryTest {
 			searchQuery = "mountains",
 			categories = setOf(Category.GENERAL, Category.ANIME),
 			purity = setOf(Purity.SFW, Purity.SKETCHY),
-			aspectRatio = "16x9",
 			updateIntervalMinutes = 30,
 			wallpaperTarget = WallpaperTarget.HOME,
 			wifiOnly = false,
@@ -88,13 +87,4 @@ class SettingsRepositoryTest {
 		assertEquals(modified, loaded)
 	}
 
-	@Test
-	fun `save and reload 10x16 aspect ratio`() = runTest {
-		val repository = createRepository()
-		val settings = AppSettings(aspectRatio = "10x16")
-		repository.save(settings)
-
-		val loaded = repository.settings.first { it.aspectRatio == "10x16" }
-		assertEquals("10x16", loaded.aspectRatio)
-	}
 }

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
@@ -47,7 +47,7 @@ class WallhavenRepositoryTest {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		val result = repository.next(AppSettings())
+		val result = repository.next(AppSettings(), "9x16")
 		assertTrue(result.isSuccess)
 		assertEquals("w1", result.getOrNull()?.first?.id)
 
@@ -61,8 +61,8 @@ class WallhavenRepositoryTest {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		repository.next(AppSettings())
-		repository.next(AppSettings())
+		repository.next(AppSettings(), "9x16")
+		repository.next(AppSettings(), "9x16")
 
 		coVerify(exactly = 1) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -74,8 +74,8 @@ class WallhavenRepositoryTest {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		repository.next(AppSettings(searchQuery = "mountains"))
-		repository.next(AppSettings(searchQuery = "ocean"))
+		repository.next(AppSettings(searchQuery = "mountains"), "9x16")
+		repository.next(AppSettings(searchQuery = "ocean"), "9x16")
 
 		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -87,8 +87,8 @@ class WallhavenRepositoryTest {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		repository.next(AppSettings(filterColor = "cc0000"))
-		repository.next(AppSettings(filterColor = "0066cc"))
+		repository.next(AppSettings(filterColor = "cc0000"), "9x16")
+		repository.next(AppSettings(filterColor = "0066cc"), "9x16")
 
 		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -100,8 +100,8 @@ class WallhavenRepositoryTest {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		repository.next(AppSettings(sorting = Sorting.RANDOM))
-		repository.next(AppSettings(sorting = Sorting.VIEWS))
+		repository.next(AppSettings(sorting = Sorting.RANDOM), "9x16")
+		repository.next(AppSettings(sorting = Sorting.VIEWS), "9x16")
 
 		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -113,8 +113,21 @@ class WallhavenRepositoryTest {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		repository.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_MONTH))
-		repository.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_YEAR))
+		repository.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_MONTH), "9x16")
+		repository.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_YEAR), "9x16")
+
+		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `cache invalidates when aspect ratio changes`() = runTest {
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		repository.next(AppSettings(), "9x16")
+		repository.next(AppSettings(), "16x9")
 
 		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -123,7 +136,7 @@ class WallhavenRepositoryTest {
 	fun `returns NoResultsException when API returns empty list`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(0)
 
-		val result = repository.next(AppSettings())
+		val result = repository.next(AppSettings(), "9x16")
 		assertTrue(result.isFailure)
 		assertTrue(result.exceptionOrNull() is NoResultsException)
 	}
@@ -151,15 +164,15 @@ class WallhavenRepositoryTest {
 		}
 
 		// First call - should request page 1
-		val res1 = repository.next(AppSettings(sorting = Sorting.VIEWS))
+		val res1 = repository.next(AppSettings(sorting = Sorting.VIEWS), "9x16")
 		assertEquals("w-1-1", res1.getOrNull()?.first?.id)
 
 		// Second call - cache is empty, should request page 2
-		val res2 = repository.next(AppSettings(sorting = Sorting.VIEWS))
+		val res2 = repository.next(AppSettings(sorting = Sorting.VIEWS), "9x16")
 		assertEquals("w-2-1", res2.getOrNull()?.first?.id)
 
 		// Third call - cache is empty, currentPage (3) > lastPage (2), should wrap back and request page 1
-		val res3 = repository.next(AppSettings(sorting = Sorting.VIEWS))
+		val res3 = repository.next(AppSettings(sorting = Sorting.VIEWS), "9x16")
 		assertEquals("w-1-1", res3.getOrNull()?.first?.id)
 
 		// Verify page 1 was requested twice, page 2 was requested once


### PR DESCRIPTION
## Summary

Removes the user-facing aspect ratio setting and replaces it with automatic detection via `WindowManager`. The detected ratio is matched against a curated list of Wallhaven-supported ratios by closest float distance.

- `closestAspectRatio(width, height)` is computed in `WallpaperService` at search time and passed through to `WallhavenRepository.next()`
- Candidate list (`"9x16", "10x16", "3x4", "16x9", "16x10", "4x3", "21x9", "1x1"`) was chosen by querying Wallhaven's API for `meta.total` per ratio — sparse ratios like 9x18/9x19/9x20 (~300 results each) are excluded in favour of falling back to 9x16; `3x4` is added for portrait tablets
- API 26–29 compatibility handled via a `@Suppress("DEPRECATION")` fallback using `WindowManager.defaultDisplay.getRealMetrics()`
- The `NoResultsWithRatioHint` error now triggers whenever an API key is present, since a ratio is always supplied