### PR TITLE
feature: multi-keyword search fan-out

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
@@ -3,6 +3,9 @@ package xyz.attacktive.wallhavend.domain.repository
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import xyz.attacktive.wallhavend.data.api.WallhavenApiService
@@ -24,7 +27,7 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 	private var lastPage = 1
 
 	private data class SearchKey(
-		val query: String?,
+		val keywords: List<String>,
 		val categories: String,
 		val purity: String,
 		val ratios: String?,
@@ -35,7 +38,7 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 	)
 
 	private fun AppSettings.toSearchKey(aspectRatio: String) = SearchKey(
-		query = searchQuery.ifBlank { null },
+		keywords = searchQuery.trim().split(Regex("[,;|\\s]+")).filter { it.isNotBlank() },
 		categories = categories.toBitString(),
 		purity = purity.toBitString(),
 		ratios = aspectRatio,
@@ -91,27 +94,45 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 			}
 		}
 
-		val response = wallhavenApiService.search(
-			query = key.query,
-			categories = key.categories,
-			purity = key.purity,
-			ratios = key.ratios,
-			sorting = key.sorting.apiValue,
-			seed = if (key.sorting == Sorting.RANDOM) {
-				randomSeed()
+		val effectiveKeywords: List<String?> = key.keywords.ifEmpty { listOf(null) }
+
+		val responses = coroutineScope {
+			effectiveKeywords
+				.map { keyword ->
+					async {
+						wallhavenApiService.search(
+							query = keyword,
+							categories = key.categories,
+							purity = key.purity,
+							ratios = key.ratios,
+							sorting = key.sorting.apiValue,
+							seed = if (key.sorting == Sorting.RANDOM) {
+								randomSeed()
+							} else {
+								null
+							},
+							topRange = key.toplistRange,
+							page = pageToFetch,
+							colors = key.colors,
+							apiKey = key.apiKey
+						)
+					}
+				}
+				.awaitAll()
+		}
+
+		val firstResponse = responses.first()
+		currentPage = firstResponse.meta.currentPage + 1
+		lastPage = firstResponse.meta.lastPage
+
+		cache = ArrayDeque(
+			if (effectiveKeywords.size > 1) {
+				responses.flatMap { it.data }
+					.shuffled()
 			} else {
-				null
-			},
-			topRange = key.toplistRange,
-			page = pageToFetch,
-			colors = key.colors,
-			apiKey = key.apiKey
+				responses.single().data
+			}
 		)
-
-		currentPage = response.meta.currentPage + 1
-		lastPage = response.meta.lastPage
-
-		cache = ArrayDeque(response.data)
 	}
 
 	private fun randomSeed() = (('a'..'z') + ('A'..'Z') + ('0'..'9'))

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
@@ -28,10 +28,20 @@ class WallhavenRepositoryTest {
 
 	private fun makeDto(id: String) = WallpaperDto(id, "https://wallhaven.cc/$id", "https://cdn/w/$id.jpg", "1920x1080", "image/jpeg")
 
-	private fun makePage(count: Int, currentPage: Int = 1, lastPage: Int = 1) = SearchResponseDto(
-		data = (1..count).map { makeDto(if (currentPage == 1 && lastPage == 1) "w$it" else "w-${currentPage}-${it}") },
-		meta = MetaDto(currentPage, lastPage, 24, count)
-	)
+	private fun makePage(count: Int, currentPage: Int = 1, lastPage: Int = 1, idPrefix: String = "w"): SearchResponseDto {
+		val data = (1..count)
+			.map {
+				val id = if (currentPage == 1 && lastPage == 1) {
+					"$idPrefix$it"
+				} else {
+					"$idPrefix-${currentPage}-${it}"
+				}
+
+				makeDto(id)
+			}
+
+		return SearchResponseDto(data, MetaDto(currentPage, lastPage, 24, count))
+	}
 
 	private fun makeFile(id: String) = File("/tmp/$id.jpg")
 
@@ -189,5 +199,90 @@ class WallhavenRepositoryTest {
 				sorting = any(), seed = any(), topRange = any(), page = 2, colors = any(), apiKey = any()
 			)
 		}
+	}
+
+	@Test
+	fun `multi-keyword query fans out parallel API calls`() = runTest {
+		coEvery {
+			wallhavenApiService.search(
+				query = "ocean", categories = any(), purity = any(), ratios = any(),
+				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
+			)
+		} returns makePage(2, idPrefix = "ocean")
+
+		coEvery {
+			wallhavenApiService.search(
+				query = "mountains", categories = any(), purity = any(), ratios = any(),
+				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
+			)
+		} returns makePage(2, idPrefix = "mountains")
+
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		val result = repository.next(AppSettings(searchQuery = "ocean mountains"), "9x16")
+		assertTrue(result.isSuccess)
+
+		coVerify(exactly = 1) {
+			wallhavenApiService.search(
+				query = "ocean", categories = any(), purity = any(), ratios = any(),
+				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
+			)
+		}
+
+		coVerify(exactly = 1) {
+			wallhavenApiService.search(
+				query = "mountains", categories = any(), purity = any(), ratios = any(),
+				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
+			)
+		}
+	}
+
+	@Test
+	fun `multi-keyword merges results into combined pool`() = runTest {
+		coEvery {
+			wallhavenApiService.search(
+				query = "ocean", categories = any(), purity = any(), ratios = any(),
+				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
+			)
+		} returns makePage(3, idPrefix = "ocean")
+
+		coEvery {
+			wallhavenApiService.search(
+				query = "mountains", categories = any(), purity = any(), ratios = any(),
+				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
+			)
+		} returns makePage(2, idPrefix = "mountains")
+
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		val ids = mutableListOf<String>()
+		repeat(5) {
+			val result = repository.next(AppSettings(searchQuery = "ocean mountains"), "9x16")
+			ids.add(result.getOrNull()!!.first.id)
+		}
+
+		assertEquals(5, ids.size)
+		assertTrue(ids.any { it.startsWith("ocean") })
+		assertTrue(ids.any { it.startsWith("mountains") })
+		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `comma semicolon and pipe delimiters also split the query`() = runTest {
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(1)
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		for (delimiter in listOf(",", ";", "|")) {
+			val repo = WallhavenRepository(wallhavenApiService, fileManager)
+			repo.next(AppSettings(searchQuery = "ocean${delimiter}mountains"), "9x16")
+		}
+
+		coVerify(exactly = 6) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 }


### PR DESCRIPTION
## Summary

- Split `searchQuery` on whitespace and `,;|` delimiters into individual keywords
- Fire one parallel API request per keyword using coroutines (`async`/`awaitAll`)
- Merge and shuffle all results into the cache pool