### PR TITLE
feature: add setting to reject wallpapers below screen resolution

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/data/api/WallhavenApiService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/data/api/WallhavenApiService.kt
@@ -11,6 +11,7 @@ interface WallhavenApiService {
 		@Query("categories") categories: String,
 		@Query("purity") purity: String,
 		@Query(value = "ratios", encoded = true) ratios: String?,
+		@Query("atleast") atleast: String?,
 		@Query("sorting") sorting: String,
 		@Query("seed") seed: String?,
 		@Query("topRange") topRange: String?,

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
@@ -18,7 +18,8 @@ data class AppSettings(
 	val autoStartOnBoot: Boolean = true,
 	val filterColor: String = "",
 	val sorting: Sorting = Sorting.RANDOM,
-	val toplistRange: ToplistRange = ToplistRange.ONE_MONTH
+	val toplistRange: ToplistRange = ToplistRange.ONE_MONTH,
+	val avoidBlurryWallpapers: Boolean = false
 )
 
 val UPDATE_INTERVAL_OPTIONS = listOf(1, 5, 15, 30, 60, 180, 360, 1440)

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/ScreenInfo.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/ScreenInfo.kt
@@ -1,0 +1,3 @@
+package xyz.attacktive.wallhavend.domain.model
+
+data class ScreenInfo(val aspectRatio: String, val width: Int, val height: Int)

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -35,6 +35,7 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 		val FILTER_COLOR = stringPreferencesKey("filter_color")
 		val SORTING = stringPreferencesKey("sorting")
 		val TOPLIST_RANGE = stringPreferencesKey("toplist_range")
+		val AVOID_BLURRY_WALLPAPERS = booleanPreferencesKey("avoid_blurry_wallpapers")
 		val LAST_UPDATED_MS = longPreferencesKey("last_updated_ms")
 		val CURRENT_WALLPAPER_PATH = stringPreferencesKey("current_wallpaper_path")
 		val PREVIOUS_WALLPAPER_PATH = stringPreferencesKey("previous_wallpaper_path")
@@ -61,7 +62,8 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 				autoStartOnBoot = preferences[Keys.AUTO_START_ON_BOOT] ?: true,
 				filterColor = preferences[Keys.FILTER_COLOR] ?: "",
 				sorting = Sorting.fromApiValue(preferences[Keys.SORTING] ?: "random"),
-				toplistRange = ToplistRange.fromApiValue(preferences[Keys.TOPLIST_RANGE] ?: "1M")
+				toplistRange = ToplistRange.fromApiValue(preferences[Keys.TOPLIST_RANGE] ?: "1M"),
+				avoidBlurryWallpapers = preferences[Keys.AVOID_BLURRY_WALLPAPERS] ?: false
 			)
 			.also { logger.debug(TAG, "read: ${it.redactedForLog()}") }
 		}
@@ -88,6 +90,7 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 			preferences[Keys.FILTER_COLOR] = settings.filterColor
 			preferences[Keys.SORTING] = settings.sorting.apiValue
 			preferences[Keys.TOPLIST_RANGE] = settings.toplistRange.apiValue
+			preferences[Keys.AVOID_BLURRY_WALLPAPERS] = settings.avoidBlurryWallpapers
 		}
 
 		logger.debug(TAG, "save() completed")

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
@@ -13,6 +13,7 @@ import xyz.attacktive.wallhavend.data.api.dto.WallpaperDto
 import xyz.attacktive.wallhavend.data.api.dto.toDomain
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.NoResultsException
+import xyz.attacktive.wallhavend.domain.model.ScreenInfo
 import xyz.attacktive.wallhavend.domain.model.Wallpaper
 import xyz.attacktive.wallhavend.domain.model.query.Sorting
 import xyz.attacktive.wallhavend.domain.model.query.toBitString
@@ -31,17 +32,23 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 		val categories: String,
 		val purity: String,
 		val ratios: String?,
+		val atleast: String?,
 		val colors: String?,
 		val apiKey: String?,
 		val sorting: Sorting,
 		val toplistRange: String?
 	)
 
-	private fun AppSettings.toSearchKey(aspectRatio: String) = SearchKey(
+	private fun AppSettings.toSearchKey(screenInfo: ScreenInfo) = SearchKey(
 		keywords = searchQuery.trim().split(Regex("[,;|\\s]+")).filter { it.isNotBlank() },
 		categories = categories.toBitString(),
 		purity = purity.toBitString(),
-		ratios = aspectRatio,
+		ratios = screenInfo.aspectRatio,
+		atleast = if (avoidBlurryWallpapers) {
+			"${screenInfo.width}x${screenInfo.height}"
+		} else {
+			null
+		},
 		colors = filterColor.ifBlank { null },
 		apiKey = apiKey.ifBlank { null },
 		sorting = sorting,
@@ -52,8 +59,8 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 		}
 	)
 
-	suspend fun next(settings: AppSettings, aspectRatio: String): Result<Pair<Wallpaper, File>> = mutex.withLock {
-		val key = settings.toSearchKey(aspectRatio)
+	suspend fun next(settings: AppSettings, screenInfo: ScreenInfo): Result<Pair<Wallpaper, File>> = mutex.withLock {
+		val key = settings.toSearchKey(screenInfo)
 		if (key != cacheKey) {
 			cache.clear()
 			cacheKey = key
@@ -105,6 +112,7 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 							categories = key.categories,
 							purity = key.purity,
 							ratios = key.ratios,
+							atleast = key.atleast,
 							sorting = key.sorting.apiValue,
 							seed = if (key.sorting == Sorting.RANDOM) {
 								randomSeed()

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -37,6 +37,7 @@ import xyz.attacktive.wallhavend.WallhavendApplication.Companion.NOTIFICATION_ID
 import xyz.attacktive.wallhavend.domain.model.AppError
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.NoResultsException
+import xyz.attacktive.wallhavend.domain.model.ScreenInfo
 import xyz.attacktive.wallhavend.domain.model.UnsupportedFormatException
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.closestAspectRatio
@@ -111,7 +112,7 @@ class WallpaperService: Service() {
 	}
 
 	private suspend fun handleOnlineUpdate(settings: AppSettings) {
-		wallhavenRepository.next(settings, screenAspectRatio())
+		wallhavenRepository.next(settings, screenInfo())
 			.fold(
 				onSuccess = { (_, file) -> onWallpaperFetched(file, settings) },
 				onFailure = { throwable -> onFetchError(throwable, settings) }
@@ -250,7 +251,7 @@ class WallpaperService: Service() {
 		}
 	}
 
-	private fun screenAspectRatio(): String {
+	private fun screenInfo(): ScreenInfo {
 		val windowManager = getSystemService(WindowManager::class.java)
 
 		val (width, height) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -260,7 +261,7 @@ class WallpaperService: Service() {
 			legacyScreenDimensions(windowManager)
 		}
 
-		return closestAspectRatio(width, height)
+		return ScreenInfo(closestAspectRatio(width, height), width, height)
 	}
 
 	@Suppress("DEPRECATION")

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -375,6 +375,14 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 			}
 		}
 	}
+
+	Spacer(Modifier.height(16.dp))
+	ToggleSetting(
+		label = stringResource(R.string.settings_label_avoid_blurry),
+		subtitle = stringResource(R.string.settings_subtitle_avoid_blurry),
+		checked = settings.avoidBlurryWallpapers,
+		onToggle = { onSave(settings.copy(avoidBlurryWallpapers = it)) }
+	)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
 	<string name="settings_toplist_range_3m">3 months</string>
 	<string name="settings_toplist_range_6m">6 months</string>
 	<string name="settings_toplist_range_1y">1 year</string>
+	<string name="settings_label_avoid_blurry">Avoid blurry wallpapers</string>
+	<string name="settings_subtitle_avoid_blurry">Only fetch wallpapers at least as large as your screen</string>
 	<string name="settings_label_update_interval">UPDATE INTERVAL</string>
 	<string name="settings_label_wallpaper_target">WALLPAPER TARGET</string>
 	<string name="settings_hint_wallpaper_target">Lock screen may not work on some devices (e.g. Samsung One UI)</string>

--- a/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -87,4 +88,14 @@ class SettingsRepositoryTest {
 		assertEquals(modified, loaded)
 	}
 
+	@Test
+	fun `avoidBlurryWallpapers defaults to false and round-trips`() = runTest {
+		val repository = createRepository()
+		assertFalse(repository.settings.first().avoidBlurryWallpapers)
+
+		repository.save(AppSettings(searchQuery = "marker", avoidBlurryWallpapers = true))
+
+		val loaded = repository.settings.first { it.searchQuery == "marker" }
+		assertTrue(loaded.avoidBlurryWallpapers)
+	}
 }

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
@@ -15,6 +15,7 @@ import xyz.attacktive.wallhavend.data.api.dto.SearchResponseDto
 import xyz.attacktive.wallhavend.data.api.dto.WallpaperDto
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.NoResultsException
+import xyz.attacktive.wallhavend.domain.model.ScreenInfo
 import xyz.attacktive.wallhavend.domain.model.Wallpaper
 import xyz.attacktive.wallhavend.domain.model.query.Sorting
 import xyz.attacktive.wallhavend.domain.model.query.ToplistRange
@@ -25,6 +26,9 @@ class WallhavenRepositoryTest {
 	private val wallhavenApiService = mockk<WallhavenApiService>()
 	private val fileManager = mockk<WallpaperFileManager>()
 	private lateinit var repository: WallhavenRepository
+
+	private val portraitScreen = ScreenInfo("9x16", 1080, 2400)
+	private val landscapeScreen = ScreenInfo("16x9", 2400, 1080)
 
 	private fun makeDto(id: String) = WallpaperDto(id, "https://wallhaven.cc/$id", "https://cdn/w/$id.jpg", "1920x1080", "image/jpeg")
 
@@ -52,101 +56,148 @@ class WallhavenRepositoryTest {
 
 	@Test
 	fun `next fetches from API and returns first result`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
 		coEvery { fileManager.download(any()) } answers {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		val result = repository.next(AppSettings(), "9x16")
+		val result = repository.next(AppSettings(), portraitScreen)
 		assertTrue(result.isSuccess)
 		assertEquals("w1", result.getOrNull()?.first?.id)
 
-		coVerify(exactly = 1) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 1) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 
 	@Test
 	fun `next reuses cache on second call`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
 		coEvery { fileManager.download(any()) } answers {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		repository.next(AppSettings(), "9x16")
-		repository.next(AppSettings(), "9x16")
+		repository.next(AppSettings(), portraitScreen)
+		repository.next(AppSettings(), portraitScreen)
 
-		coVerify(exactly = 1) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 1) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 
 	@Test
 	fun `cache invalidates when query changes`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
 		coEvery { fileManager.download(any()) } answers {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		repository.next(AppSettings(searchQuery = "mountains"), "9x16")
-		repository.next(AppSettings(searchQuery = "ocean"), "9x16")
+		repository.next(AppSettings(searchQuery = "mountains"), portraitScreen)
+		repository.next(AppSettings(searchQuery = "ocean"), portraitScreen)
 
-		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 
 	@Test
 	fun `cache invalidates when filterColor changes`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
 		coEvery { fileManager.download(any()) } answers {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		repository.next(AppSettings(filterColor = "cc0000"), "9x16")
-		repository.next(AppSettings(filterColor = "0066cc"), "9x16")
+		repository.next(AppSettings(filterColor = "cc0000"), portraitScreen)
+		repository.next(AppSettings(filterColor = "0066cc"), portraitScreen)
 
-		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 
 	@Test
 	fun `cache invalidates when sorting changes`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
 		coEvery { fileManager.download(any()) } answers {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		repository.next(AppSettings(sorting = Sorting.RANDOM), "9x16")
-		repository.next(AppSettings(sorting = Sorting.VIEWS), "9x16")
+		repository.next(AppSettings(sorting = Sorting.RANDOM), portraitScreen)
+		repository.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen)
 
-		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 
 	@Test
 	fun `cache invalidates when toplistRange changes`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
 		coEvery { fileManager.download(any()) } answers {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		repository.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_MONTH), "9x16")
-		repository.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_YEAR), "9x16")
+		repository.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_MONTH), portraitScreen)
+		repository.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_YEAR), portraitScreen)
 
-		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 
 	@Test
 	fun `cache invalidates when aspect ratio changes`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
 		coEvery { fileManager.download(any()) } answers {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		repository.next(AppSettings(), "9x16")
-		repository.next(AppSettings(), "16x9")
+		repository.next(AppSettings(), portraitScreen)
+		repository.next(AppSettings(), landscapeScreen)
 
-		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `cache invalidates when avoidBlurryWallpapers changes`() = runTest {
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		repository.next(AppSettings(avoidBlurryWallpapers = false), portraitScreen)
+		repository.next(AppSettings(avoidBlurryWallpapers = true), portraitScreen)
+
+		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `atleast is sent as screen resolution when avoidBlurryWallpapers is on`() = runTest {
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		repository.next(AppSettings(avoidBlurryWallpapers = true), portraitScreen)
+
+		coVerify(exactly = 1) {
+			wallhavenApiService.search(
+				query = any(), categories = any(), purity = any(), ratios = any(), atleast = "1080x2400",
+				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
+			)
+		}
+	}
+
+	@Test
+	fun `atleast is omitted when avoidBlurryWallpapers is off`() = runTest {
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		repository.next(AppSettings(avoidBlurryWallpapers = false), portraitScreen)
+
+		coVerify(exactly = 1) {
+			wallhavenApiService.search(
+				query = any(), categories = any(), purity = any(), ratios = any(), atleast = null,
+				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
+			)
+		}
 	}
 
 	@Test
 	fun `returns NoResultsException when API returns empty list`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(0)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(0)
 
-		val result = repository.next(AppSettings(), "9x16")
+		val result = repository.next(AppSettings(), portraitScreen)
 		assertTrue(result.isFailure)
 		assertTrue(result.exceptionOrNull() is NoResultsException)
 	}
@@ -156,7 +207,7 @@ class WallhavenRepositoryTest {
 		// Page 1: lastPage = 2, returns 1 item
 		coEvery {
 			wallhavenApiService.search(
-				query = any(), categories = any(), purity = any(), ratios = any(),
+				query = any(), categories = any(), purity = any(), ratios = any(), atleast = any(),
 				sorting = any(), seed = any(), topRange = any(), page = 1, colors = any(), apiKey = any()
 			)
 		} returns makePage(count = 1, currentPage = 1, lastPage = 2)
@@ -164,7 +215,7 @@ class WallhavenRepositoryTest {
 		// Page 2: lastPage = 2, returns 1 item
 		coEvery {
 			wallhavenApiService.search(
-				query = any(), categories = any(), purity = any(), ratios = any(),
+				query = any(), categories = any(), purity = any(), ratios = any(), atleast = any(),
 				sorting = any(), seed = any(), topRange = any(), page = 2, colors = any(), apiKey = any()
 			)
 		} returns makePage(count = 1, currentPage = 2, lastPage = 2)
@@ -174,28 +225,28 @@ class WallhavenRepositoryTest {
 		}
 
 		// First call - should request page 1
-		val res1 = repository.next(AppSettings(sorting = Sorting.VIEWS), "9x16")
+		val res1 = repository.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen)
 		assertEquals("w-1-1", res1.getOrNull()?.first?.id)
 
 		// Second call - cache is empty, should request page 2
-		val res2 = repository.next(AppSettings(sorting = Sorting.VIEWS), "9x16")
+		val res2 = repository.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen)
 		assertEquals("w-2-1", res2.getOrNull()?.first?.id)
 
 		// Third call - cache is empty, currentPage (3) > lastPage (2), should wrap back and request page 1
-		val res3 = repository.next(AppSettings(sorting = Sorting.VIEWS), "9x16")
+		val res3 = repository.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen)
 		assertEquals("w-1-1", res3.getOrNull()?.first?.id)
 
 		// Verify page 1 was requested twice, page 2 was requested once
 		coVerify(exactly = 2) {
 			wallhavenApiService.search(
-				query = any(), categories = any(), purity = any(), ratios = any(),
+				query = any(), categories = any(), purity = any(), ratios = any(), atleast = any(),
 				sorting = any(), seed = any(), topRange = any(), page = 1, colors = any(), apiKey = any()
 			)
 		}
 
 		coVerify(exactly = 1) {
 			wallhavenApiService.search(
-				query = any(), categories = any(), purity = any(), ratios = any(),
+				query = any(), categories = any(), purity = any(), ratios = any(), atleast = any(),
 				sorting = any(), seed = any(), topRange = any(), page = 2, colors = any(), apiKey = any()
 			)
 		}
@@ -205,14 +256,14 @@ class WallhavenRepositoryTest {
 	fun `multi-keyword query fans out parallel API calls`() = runTest {
 		coEvery {
 			wallhavenApiService.search(
-				query = "ocean", categories = any(), purity = any(), ratios = any(),
+				query = "ocean", categories = any(), purity = any(), ratios = any(), atleast = any(),
 				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
 			)
 		} returns makePage(2, idPrefix = "ocean")
 
 		coEvery {
 			wallhavenApiService.search(
-				query = "mountains", categories = any(), purity = any(), ratios = any(),
+				query = "mountains", categories = any(), purity = any(), ratios = any(), atleast = any(),
 				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
 			)
 		} returns makePage(2, idPrefix = "mountains")
@@ -221,19 +272,19 @@ class WallhavenRepositoryTest {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		val result = repository.next(AppSettings(searchQuery = "ocean mountains"), "9x16")
+		val result = repository.next(AppSettings(searchQuery = "ocean mountains"), portraitScreen)
 		assertTrue(result.isSuccess)
 
 		coVerify(exactly = 1) {
 			wallhavenApiService.search(
-				query = "ocean", categories = any(), purity = any(), ratios = any(),
+				query = "ocean", categories = any(), purity = any(), ratios = any(), atleast = any(),
 				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
 			)
 		}
 
 		coVerify(exactly = 1) {
 			wallhavenApiService.search(
-				query = "mountains", categories = any(), purity = any(), ratios = any(),
+				query = "mountains", categories = any(), purity = any(), ratios = any(), atleast = any(),
 				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
 			)
 		}
@@ -243,14 +294,14 @@ class WallhavenRepositoryTest {
 	fun `multi-keyword merges results into combined pool`() = runTest {
 		coEvery {
 			wallhavenApiService.search(
-				query = "ocean", categories = any(), purity = any(), ratios = any(),
+				query = "ocean", categories = any(), purity = any(), ratios = any(), atleast = any(),
 				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
 			)
 		} returns makePage(3, idPrefix = "ocean")
 
 		coEvery {
 			wallhavenApiService.search(
-				query = "mountains", categories = any(), purity = any(), ratios = any(),
+				query = "mountains", categories = any(), purity = any(), ratios = any(), atleast = any(),
 				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
 			)
 		} returns makePage(2, idPrefix = "mountains")
@@ -261,28 +312,28 @@ class WallhavenRepositoryTest {
 
 		val ids = mutableListOf<String>()
 		repeat(5) {
-			val result = repository.next(AppSettings(searchQuery = "ocean mountains"), "9x16")
+			val result = repository.next(AppSettings(searchQuery = "ocean mountains"), portraitScreen)
 			ids.add(result.getOrNull()!!.first.id)
 		}
 
 		assertEquals(5, ids.size)
 		assertTrue(ids.any { it.startsWith("ocean") })
 		assertTrue(ids.any { it.startsWith("mountains") })
-		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 
 	@Test
 	fun `comma semicolon and pipe delimiters also split the query`() = runTest {
-		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(1)
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(1)
 		coEvery { fileManager.download(any()) } answers {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
 		for (delimiter in listOf(",", ";", "|")) {
 			val repo = WallhavenRepository(wallhavenApiService, fileManager)
-			repo.next(AppSettings(searchQuery = "ocean${delimiter}mountains"), "9x16")
+			repo.next(AppSettings(searchQuery = "ocean${delimiter}mountains"), portraitScreen)
 		}
 
-		coVerify(exactly = 6) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 6) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 }


### PR DESCRIPTION
## Summary

- Adds an **Avoid blurry wallpapers** toggle (default: off) to the Content tab of Settings
- When enabled, the device's native screen resolution is passed as Wallhaven's atleast parameter, filtering out wallpapers smaller than the screen server-side
- New ScreenInfo data class carries the aspect ratio plus raw pixel dimensions from WallpaperService down to WallhavenRepository, which owns the settings-to-search-parameter translation
- The flag participates in SearchKey, so toggling it invalidates the wallpaper cache and triggers a refetch
- Default off preserves existing behaviour for current users; no migration needed

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)