### PR TITLE
ci: fall back to commit log for Google Play release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@v6'
+        with:
+          fetch-depth: 0
 
       - name: 'Set up JDK'
         uses: 'actions/setup-java@v5'
@@ -60,10 +62,24 @@ jobs:
           RELEASE_NOTES: ${{ steps.release_notes.outputs.body }}
         run: |
           mkdir -p whatsnew
-          printf '%s' "$RELEASE_NOTES" \
+          NOTES=$(printf '%s' "$RELEASE_NOTES" \
             | sed '/^## What'\''s Changed$/d' \
             | sed 's/ by @[^ ]* in [^ ]*//g' \
-            | cut -c1-500 > whatsnew/whatsnew-en-US
+            | sed '/^\*\*Full Changelog\*\*:/d' \
+            | sed '/^[[:space:]]*$/d')
+
+          if [ -z "$NOTES" ]; then
+            PREVIOUS_TAG=$(git describe --tags --abbrev=0 '${{ github.ref_name }}^' 2>/dev/null || true)
+            if [ -n "$PREVIOUS_TAG" ]; then
+              RANGE="$PREVIOUS_TAG..${{ github.ref_name }}"
+            else
+              RANGE='${{ github.ref_name }}'
+            fi
+
+            NOTES=$(git log "$RANGE" --pretty='- %s' | grep -v '^- chore: bump version' || true)
+          fi
+
+          printf '%s' "$NOTES" | head -c 500 > whatsnew/whatsnew-en-US
 
       - name: 'Upload AAB to Google Play'
         uses: 'r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5'


### PR DESCRIPTION
## Summary

- GitHub's generate-notes API lists merged pull requests only, so a release containing no PR (like 1.6.1) produced a body that was nothing but the Full Changelog compare link — which then shipped to Google Play verbatim
- The whatsnew step now strips that compare-link line and blank lines; if nothing remains, it falls back to commit subjects between the previous tag and the released tag, filtering out version-bump commits
- Truncation fixed from per-line (cut -c1-500) to 500 characters total (head -c 500), matching Google Play's actual limit
- Checkout now fetches full history so tags are available for the fallback

Verified locally against the last three releases: 1.6.1 now yields its actual change via the fallback, while 1.6.0 and 1.5.1 keep their PR-title output (minus the compare link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)