### PR TITLE
Fix offline wallpaper-state persistence and tidy service internals

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/BootReceiver.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/BootReceiver.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
@@ -21,8 +22,8 @@ class BootReceiver: BroadcastReceiver() {
 		}
 
 		val pendingResult = goAsync()
-
-		CoroutineScope(Dispatchers.IO).launch {
+		val scope = CoroutineScope(Dispatchers.IO)
+		scope.launch {
 			try {
 				val settings = settingsRepository.settings.first()
 				if (settings.autoStartOnBoot) {
@@ -30,6 +31,7 @@ class BootReceiver: BroadcastReceiver() {
 				}
 			} finally {
 				pendingResult.finish()
+				scope.cancel()
 			}
 		}
 	}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperFileManager.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperFileManager.kt
@@ -29,7 +29,7 @@ class WallpaperFileManager(private val wallpaperDir: File, private val okHttpCli
 
 					val file = File(dir, "${wallpaper.id}.${wallpaper.fileExtension}")
 
-					requireNotNull(response.body)
+					response.body
 						.byteStream()
 						.use { input ->
 							file.outputStream().use { output -> input.copyTo(output) }

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -168,7 +168,7 @@ class WallpaperService: Service() {
 		postError(error)
 	}
 
-	private fun cycleFromPool(settings: AppSettings) {
+	private suspend fun cycleFromPool(settings: AppSettings) {
 		val current = stateRepository.state.value.currentWallpaperPath
 
 		val pool = fileManager.listAll()
@@ -200,6 +200,9 @@ class WallpaperService: Service() {
 					)
 				}
 
+				val lastUpdatedMs = state.lastUpdatedMs ?: System.currentTimeMillis()
+				settingsRepository.saveServiceState(lastUpdatedMs, next, state.currentWallpaperPath)
+
 				updateNotification()
 			}
 	}
@@ -224,6 +227,9 @@ class WallpaperService: Service() {
 				stateRepository.update {
 					it.copy(currentWallpaperPath = path, previousWallpaperPath = newPreviousPath)
 				}
+
+				val lastUpdatedMs = state.lastUpdatedMs ?: System.currentTimeMillis()
+				settingsRepository.saveServiceState(lastUpdatedMs, path, newPreviousPath)
 
 				updateNotification()
 			}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -99,11 +99,12 @@ class WallpaperService: Service() {
 	private suspend fun performUpdate(forceDownload: Boolean = false) {
 		val settings = settingsRepository.settings.first()
 
-		val online = isOnline()
+		val capabilities = activeNetworkCapabilities()
+		val online = capabilities?.isOnline() == true
 		stateRepository.update { it.copy(isOnline = online) }
 
-		val canDownload = online && (forceDownload || !settings.wifiOnly || isOnWifi())
-
+		val onWifi = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+		val canDownload = online && (forceDownload || !settings.wifiOnly || onWifi)
 		if (canDownload) {
 			handleOnlineUpdate(settings)
 		} else {
@@ -273,23 +274,15 @@ class WallpaperService: Service() {
 		return displayMetrics.widthPixels to displayMetrics.heightPixels
 	}
 
-	private fun isOnline(): Boolean {
-		val connectivityManager = getSystemService(ConnectivityManager::class.java)
-
-		val isConnected = connectivityManager.activeNetwork
-			?.let { connectivityManager.getNetworkCapabilities(it) }
-			?.let { it.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) && it.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) }
-
-		return isConnected == true
-	}
-
-	private fun isOnWifi(): Boolean {
+	private fun activeNetworkCapabilities(): NetworkCapabilities? {
 		val connectivityManager = getSystemService(ConnectivityManager::class.java)
 
 		return connectivityManager.activeNetwork
 			?.let { connectivityManager.getNetworkCapabilities(it) }
-			?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
 	}
+
+	private fun NetworkCapabilities.isOnline() =
+		hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) && hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
 
 	private fun buildNotification(): Notification {
 		val state = stateRepository.state.value

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -288,8 +288,11 @@ class WallpaperService: Service() {
 		val state = stateRepository.state.value
 
 		val lastUpdated = state.lastUpdatedMs
-			?.let {
-				getString(R.string.home_status_last_updated, SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(it)))
+			?.let { timestamp ->
+				val formattedTime = SimpleDateFormat("HH:mm", Locale.getDefault())
+					.format(Date(timestamp))
+
+				getString(R.string.home_status_last_updated, formattedTime)
 			}
 			?: getString(R.string.service_status_never)
 

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -123,13 +123,7 @@ class WallpaperService: Service() {
 		applyWallpaper(file, settings.wallpaperTarget)
 			.fold(
 				onSuccess = {
-					val remaining = if (settings.poolSize == 0) {
-						fileManager.trimToSize(0)
-						emptyList()
-					} else {
-						fileManager.trimToSize(settings.poolSize)
-					}
-
+					val remaining = fileManager.trimToSize(settings.poolSize)
 					val paths = remaining.map { it.absolutePath }
 					val now = System.currentTimeMillis()
 

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
@@ -172,9 +172,12 @@ private fun StatusCard(state: ServiceState) {
 					}
 				)
 
-				state.lastUpdatedMs?.let {
+				state.lastUpdatedMs?.let { timestamp ->
+					val formattedTime = SimpleDateFormat("HH:mm", LocalLocale.current.platformLocale)
+						.format(Date(timestamp))
+
 					Text(
-						text = stringResource(R.string.home_status_last_updated, SimpleDateFormat("HH:mm", LocalLocale.current.platformLocale).format(Date(it))),
+						text = stringResource(R.string.home_status_last_updated, formattedTime),
 						style = MaterialTheme.typography.bodySmall
 					)
 				}


### PR DESCRIPTION
Code-review findings from a pass over the service/repository layer — two behavioral fixes and a set of cleanups, each in its own commit.

## Fixes
- **Persist wallpaper state on offline cycling and pool applies.** Previously only the online download path wrote the current/previous wallpaper to DataStore via `saveServiceState`; offline cycling (`cycleFromPool`) and manual pool applies (`applySpecificPath`) only mutated the in-memory `ServiceStateRepository`, so the selection was lost after process death. Both paths now persist, matching `HomeViewModel.deleteFromPool`.
- **Cancel the `BootReceiver` coroutine scope** after the boot-start work finishes, instead of leaving a detached scope.

## Cleanups (no behavior change)
- Drop the redundant `poolSize == 0` branch in `onWallpaperFetched` — `trimToSize(0)` already deletes everything and returns an empty list.
- Resolve `NetworkCapabilities` once per `performUpdate` instead of re-fetching `ConnectivityManager` separately in `isOnline()` and `isOnWifi()`.
- Drop the redundant `requireNotNull(response.body)` in `WallpaperFileManager` (already dereferenced non-null above; non-null in OkHttp 5).
- Extract the notification/status timestamp formatting into a named local in `WallpaperService` and `HomeScreen`.

Compiles clean; existing unit-test suite passes. The notification/foreground-service behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)