### PR TITLE
fix: avoid wallpaper OOM and premature error dismissal

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -13,7 +13,6 @@ import android.app.Service
 import android.app.WallpaperManager
 import android.content.Context
 import android.content.Intent
-import android.graphics.BitmapFactory
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
@@ -231,17 +230,17 @@ class WallpaperService: Service() {
 	}
 
 	private fun applyWallpaper(file: File, target: WallpaperTarget) = runCatching {
-		val bitmap = BitmapFactory.decodeFile(file.absolutePath)
-			?: error("Failed to decode bitmap from ${file.name}")
-
 		val flags = when (target) {
 			WallpaperTarget.HOME -> WallpaperManager.FLAG_SYSTEM
 			WallpaperTarget.LOCK -> WallpaperManager.FLAG_LOCK
 			WallpaperTarget.BOTH -> WallpaperManager.FLAG_SYSTEM or WallpaperManager.FLAG_LOCK
 		}
 
-		getSystemService(WallpaperManager::class.java).setBitmap(bitmap, null, true, flags)
-		bitmap.recycle()
+		file.inputStream()
+			.use { input ->
+				getSystemService(WallpaperManager::class.java)
+					.setStream(input, null, true, flags)
+			}
 	}
 
 	private fun postError(error: AppError) {

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -18,6 +18,7 @@ import android.net.NetworkCapabilities
 import android.os.Build
 import android.util.DisplayMetrics
 import android.view.WindowManager
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -48,15 +49,21 @@ import xyz.attacktive.wallhavend.domain.repository.WallhavenRepository
 class WallpaperService: Service() {
 	@Inject
 	lateinit var settingsRepository: SettingsRepository
+
 	@Inject
 	lateinit var wallhavenRepository: WallhavenRepository
+
 	@Inject
 	lateinit var fileManager: WallpaperFileManager
+
 	@Inject
 	lateinit var stateRepository: ServiceStateRepository
 
-	private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+	@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+	internal var serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
 	private var timerJob: Job? = null
+	private var errorClearJob: Job? = null
 
 	override fun onBind(intent: Intent?) = null
 
@@ -243,10 +250,12 @@ class WallpaperService: Service() {
 			}
 	}
 
-	private fun postError(error: AppError) {
+	@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+	internal fun postError(error: AppError) {
 		stateRepository.update { it.copy(error = error) }
 
-		serviceScope.launch {
+		errorClearJob?.cancel()
+		errorClearJob = serviceScope.launch {
 			delay(10_000.milliseconds)
 			stateRepository.update { it.copy(error = null) }
 		}

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallpaperServiceErrorTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallpaperServiceErrorTest.kt
@@ -1,0 +1,39 @@
+package xyz.attacktive.wallhavend
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import xyz.attacktive.wallhavend.domain.model.AppError
+import xyz.attacktive.wallhavend.domain.repository.ServiceStateRepository
+import xyz.attacktive.wallhavend.domain.service.WallpaperService
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WallpaperServiceErrorTest {
+	@Test
+	fun `a newer error survives the older error's auto-clear timer`() = runTest {
+		val stateRepository = ServiceStateRepository()
+		val service = WallpaperService()
+		service.stateRepository = stateRepository
+		service.serviceScope = CoroutineScope(StandardTestDispatcher(testScheduler))
+
+		service.postError(AppError.NoResults)
+		testScheduler.advanceTimeBy(5_000)
+
+		service.postError(AppError.UnsupportedFormat)
+		testScheduler.advanceTimeBy(6_000)
+		testScheduler.runCurrent()
+
+		// The first error's 10s timer has now elapsed; it must not clear the newer error.
+		assertEquals(AppError.UnsupportedFormat, stateRepository.state.value.error)
+
+		testScheduler.advanceTimeBy(5_000)
+		testScheduler.runCurrent()
+
+		// The newer error's own 10s timer has elapsed, so it clears.
+		assertNull(stateRepository.state.value.error)
+	}
+}


### PR DESCRIPTION
Two independent correctness fixes in `WallpaperService`.

**#55 — OOM risk applying large wallpapers.** `applyWallpaper` decoded the full-resolution bitmap into the app heap via `BitmapFactory.decodeFile` before `setBitmap`. Wallhaven originals are often 4K–8K, so this could OOM on low-RAM devices before the wallpaper was ever applied. It now hands the file to `WallpaperManager.setStream`, letting the framework decode/scale internally — no in-process full-res allocation and no manual `recycle()`.

**#56 — newer error dismissed early.** Each `postError` launched its own coroutine that waited 10s and unconditionally cleared the error, so a second error posted within 10s of the first was wiped by the first one's timer. It now holds the clear job and cancels the outstanding one before scheduling a new clear, so only the most recent error's timer is live.

The coroutine scope is now an overridable `@VisibleForTesting` seam (rather than full Hilt-injected `CoroutineScope`, which would need a qualifier + module for a common type), letting the new `WallpaperServiceErrorTest` drive the #56 race with virtual time. #55 is a framework swap with no pure-JVM test path.

Closes #55
Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)