### PR TITLE
Added unit test for closest aspect ratio

### DIFF
--- a/app/src/test/java/xyz/attacktive/wallhavend/ClosestAspectRatioTest.java
+++ b/app/src/test/java/xyz/attacktive/wallhavend/ClosestAspectRatioTest.java
@@ -5,27 +5,27 @@ import xyz.attacktive.wallhavend.domain.model.AppSettingsKt;
 
 public class ClosestAspectRatioTest {
 	@Test
-	public void exactMatch_1080x1920_returns9x16() {
+	public void exactMatch1080x1920Returns9x16() {
 		assertEquals("9x16", AppSettingsKt.closestAspectRatio(1080, 1920));
 	}
 
 	@Test
-	public void nonExactMatch_1080x2400_fallsBackTo9x16() {
+	public void nonExactMatch1080x2400FallsBackTo9x16() {
 		assertEquals("9x16", AppSettingsKt.closestAspectRatio(1080, 2400));
 	}
 
 	@Test
-	public void widescreen_2560x1080_returns21x9() {
+	public void wideScreen2560x1080Returns21x9() {
 		assertEquals("21x9", AppSettingsKt.closestAspectRatio(2560, 1080));
 	}
 
 	@Test
-	public void square_1024x1024_returns1x1() {
+	public void square1024x1024Returns1x1() {
 		assertEquals("1x1", AppSettingsKt.closestAspectRatio(1024, 1024));
 	}
 
 	@Test
-	public void tallRatio_1080x2520_fallsBackTo9x16_notSparseRatio() {
+	public void tallRatio1080x2520FallsBackTo9x16NotSparseRatio() {
 		assertEquals("9x16", AppSettingsKt.closestAspectRatio(1080, 2520));
 	}
 

--- a/app/src/test/java/xyz/attacktive/wallhavend/ClosestAspectRatioTest.java
+++ b/app/src/test/java/xyz/attacktive/wallhavend/ClosestAspectRatioTest.java
@@ -1,0 +1,32 @@
+package xyz.attacktive.wallhavend;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import xyz.attacktive.wallhavend.domain.model.AppSettingsKt;
+
+public class ClosestAspectRatioTest {
+	@Test
+	public void exactMatch_1080x1920_returns9x16() {
+		assertEquals("9x16", AppSettingsKt.closestAspectRatio(1080, 1920));
+	}
+
+	@Test
+	public void nonExactMatch_1080x2400_fallsBackTo9x16() {
+		assertEquals("9x16", AppSettingsKt.closestAspectRatio(1080, 2400));
+	}
+
+	@Test
+	public void widescreen_2560x1080_returns21x9() {
+		assertEquals("21x9", AppSettingsKt.closestAspectRatio(2560, 1080));
+	}
+
+	@Test
+	public void square_1024x1024_returns1x1() {
+		assertEquals("1x1", AppSettingsKt.closestAspectRatio(1024, 1024));
+	}
+
+	@Test
+	public void tallRatio_1080x2520_fallsBackTo9x16_notSparseRatio() {
+		assertEquals("9x16", AppSettingsKt.closestAspectRatio(1080, 2520));
+	}
+
+}


### PR DESCRIPTION
closes #57 

I have added a unit test for **closestAspectRatio.** 

It covers all the cases you have mentioned.

When tested with **./gradlew test** -  all the added test cases had passed. (The output is given below)

**ClosestAspectRatioTest > square_1024x1024_returns1x1 PASSED**

**ClosestAspectRatioTest > widescreen_2560x1080_returns21x9 PASSED**

**ClosestAspectRatioTest > nonExactMatch_1080x2400_fallsBackTo9x16 PASSED**

**ClosestAspectRatioTest > exactMatch_1080x1920_returns9x16 PASSED**

**ClosestAspectRatioTest > tallRatio_1080x2520_fallsBackTo9x16_notSparseRatio PASSED**

Please review if any changes need to be made. 

Thanks!