### PR TITLE
feature: block wallpapers by ID

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
@@ -19,7 +19,8 @@ data class AppSettings(
 	val filterColor: String = "",
 	val sorting: Sorting = Sorting.RANDOM,
 	val toplistRange: ToplistRange = ToplistRange.ONE_MONTH,
-	val avoidBlurryWallpapers: Boolean = false
+	val avoidBlurryWallpapers: Boolean = false,
+	val blockedIds: Set<String> = emptySet()
 )
 
 val UPDATE_INTERVAL_OPTIONS = listOf(1, 5, 15, 30, 60, 180, 360, 1440)

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -36,6 +36,7 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 		val SORTING = stringPreferencesKey("sorting")
 		val TOPLIST_RANGE = stringPreferencesKey("toplist_range")
 		val AVOID_BLURRY_WALLPAPERS = booleanPreferencesKey("avoid_blurry_wallpapers")
+		val BLOCKED_IDS = stringSetPreferencesKey("blocked_ids")
 		val LAST_UPDATED_MS = longPreferencesKey("last_updated_ms")
 		val CURRENT_WALLPAPER_PATH = stringPreferencesKey("current_wallpaper_path")
 		val PREVIOUS_WALLPAPER_PATH = stringPreferencesKey("previous_wallpaper_path")
@@ -63,7 +64,8 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 				filterColor = preferences[Keys.FILTER_COLOR] ?: "",
 				sorting = Sorting.fromApiValue(preferences[Keys.SORTING] ?: "random"),
 				toplistRange = ToplistRange.fromApiValue(preferences[Keys.TOPLIST_RANGE] ?: "1M"),
-				avoidBlurryWallpapers = preferences[Keys.AVOID_BLURRY_WALLPAPERS] ?: false
+				avoidBlurryWallpapers = preferences[Keys.AVOID_BLURRY_WALLPAPERS] ?: false,
+				blockedIds = preferences[Keys.BLOCKED_IDS] ?: emptySet()
 			)
 			.also { logger.debug(TAG, "read: ${it.redactedForLog()}") }
 		}
@@ -95,6 +97,23 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 		}
 
 		logger.debug(TAG, "save() completed")
+	}
+
+	/*
+	 * The blocklist grows from the preview screen while the settings screen edits its own AppSettings
+	 * copy, so routing it through the whole-object save() would let one path clobber the other's writes.
+	 * These mutators touch only the blocked-ids key, and save() intentionally leaves that key alone.
+	 */
+	suspend fun block(id: String) {
+		dataStore.edit { preferences ->
+			preferences[Keys.BLOCKED_IDS] = (preferences[Keys.BLOCKED_IDS] ?: emptySet()) + id
+		}
+	}
+
+	suspend fun unblock(id: String) {
+		dataStore.edit { preferences ->
+			preferences[Keys.BLOCKED_IDS] = (preferences[Keys.BLOCKED_IDS] ?: emptySet()) - id
+		}
 	}
 
 	suspend fun loadServiceState() = dataStore.data.first()

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
@@ -68,22 +68,45 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 			lastPage = 1
 		}
 
-		if (cache.isEmpty()) {
-			val fetchResult = refetch(key)
-			if (fetchResult.isFailure) {
-				return@withLock Result.failure(fetchResult.exceptionOrNull()!!)
-			}
-		}
+		val selection = runCatching { selectNext(key, settings.blockedIds) }
+		val dto = selection.getOrElse { exception -> return@withLock Result.failure(exception) }
+			?: return@withLock Result.failure(NoResultsException())
 
-		if (cache.isEmpty()) {
-			return@withLock Result.failure(NoResultsException())
-		}
-
-		val dto = cache.removeFirst()
 		val wallpaper = dto.toDomain()
 
 		fileManager.download(wallpaper)
 			.map { file -> Pair(wallpaper, file) }
+	}
+
+	/*
+	 * Blocked wallpapers are filtered after the fetch, so they still occupy slots in a returned page.
+	 * Drop them when picking, and when a whole page comes back blocked, advance to the next page rather
+	 * than giving up. A genuinely empty page (no results at all) stops immediately, and an all-blocked
+	 * search is bounded so it can't loop forever before falling back to NoResults.
+	 */
+	private suspend fun selectNext(key: SearchKey, blockedIds: Set<String>): WallpaperDto? {
+		val maxBlockedPageRefetches = 5
+		var refetches = 0
+
+		while (true) {
+			while (cache.isNotEmpty() && cache.first().id in blockedIds) {
+				cache.removeFirst()
+			}
+
+			if (cache.isNotEmpty()) {
+				return cache.removeFirst()
+			}
+
+			if (refetches >= maxBlockedPageRefetches) {
+				return null
+			}
+
+			refetches++
+			val fetchedCount = refetch(key).getOrThrow()
+			if (fetchedCount == 0) {
+				return null
+			}
+		}
 	}
 
 	private suspend fun refetch(key: SearchKey) = runCatching {
@@ -141,6 +164,8 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 				responses.single().data
 			}
 		)
+
+		cache.size
 	}
 
 	private fun randomSeed() = (('a'..'z') + ('A'..'Z') + ('0'..'9'))

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/blocklist/BlocklistScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/blocklist/BlocklistScreen.kt
@@ -1,0 +1,159 @@
+package xyz.attacktive.wallhavend.ui.blocklist
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import xyz.attacktive.wallhavend.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BlocklistScreen(onNavigateBack: () -> Unit, viewModel: BlocklistViewModel = hiltViewModel()) {
+	val blockedIds by viewModel.blockedIds.collectAsStateWithLifecycle()
+
+	Scaffold(
+		topBar = {
+			TopAppBar(
+				title = { Text(stringResource(R.string.blocklist_title)) },
+				navigationIcon = {
+					IconButton(onClick = onNavigateBack) {
+						Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.cd_back))
+					}
+				}
+			)
+		}
+	) { padding ->
+		if (blockedIds.isEmpty()) {
+			Box(
+				contentAlignment = Alignment.Center,
+				modifier = Modifier
+					.fillMaxSize()
+					.padding(padding)
+					.padding(32.dp)
+			) {
+				Text(
+					text = stringResource(R.string.blocklist_empty),
+					style = MaterialTheme.typography.bodyMedium,
+					color = MaterialTheme.colorScheme.onSurfaceVariant
+				)
+			}
+
+			return@Scaffold
+		}
+
+		LazyColumn(modifier = Modifier
+			.fillMaxSize()
+			.padding(padding)
+		) {
+			items(blockedIds, key = { it }) { id ->
+				BlockedRow(id = id, onUnblock = { viewModel.unblock(id) })
+			}
+		}
+	}
+}
+
+@Composable
+private fun BlockedRow(id: String, onUnblock: () -> Unit) {
+	val uriHandler = LocalUriHandler.current
+
+	Row(
+		verticalAlignment = Alignment.CenterVertically,
+		modifier = Modifier
+			.fillMaxWidth()
+			.padding(horizontal = 16.dp, vertical = 8.dp)
+	) {
+		RevealableThumbnail(id = id)
+
+		Column(
+			modifier = Modifier
+				.weight(1f)
+				.padding(start = 16.dp)
+		) {
+			Text(
+				text = id,
+				style = MaterialTheme.typography.bodyLarge,
+				color = MaterialTheme.colorScheme.primary,
+				textDecoration = TextDecoration.Underline,
+				modifier = Modifier.clickable { uriHandler.openUri("https://wallhaven.cc/w/$id") }
+			)
+
+			Text(
+				text = stringResource(R.string.blocklist_open_hint),
+				style = MaterialTheme.typography.bodySmall,
+				color = MaterialTheme.colorScheme.onSurfaceVariant
+			)
+		}
+
+		TextButton(onClick = onUnblock) {
+			Text(stringResource(R.string.blocklist_unblock))
+		}
+	}
+}
+
+/**
+ * Blocked wallpapers are hidden behind a placeholder so opening the list doesn't re-expose content the
+ * user chose to be rid of. The thumbnail loads from the network only after an explicit tap.
+ */
+@Composable
+private fun RevealableThumbnail(id: String) {
+	var revealed by remember(id) { mutableStateOf(false) }
+
+	Box(
+		contentAlignment = Alignment.Center,
+		modifier = Modifier
+			.size(64.dp)
+			.clip(RoundedCornerShape(6.dp))
+			.background(MaterialTheme.colorScheme.surfaceVariant)
+			.clickable { revealed = true }
+	) {
+		if (revealed) {
+			AsyncImage(
+				model = "https://th.wallhaven.cc/lg/${id.take(2)}/$id.jpg",
+				contentDescription = null,
+				contentScale = ContentScale.Crop,
+				modifier = Modifier.fillMaxSize()
+			)
+		} else {
+			Icon(
+				imageVector = Icons.Filled.Visibility,
+				contentDescription = stringResource(R.string.blocklist_reveal),
+				tint = MaterialTheme.colorScheme.onSurfaceVariant
+			)
+		}
+	}
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/blocklist/BlocklistViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/blocklist/BlocklistViewModel.kt
@@ -1,0 +1,24 @@
+package xyz.attacktive.wallhavend.ui.blocklist
+
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
+
+@HiltViewModel
+class BlocklistViewModel @Inject constructor(private val settingsRepository: SettingsRepository): ViewModel() {
+	val blockedIds = settingsRepository.settings
+		.map { settings -> settings.blockedIds.sorted() }
+		.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+	fun unblock(id: String) {
+		viewModelScope.launch {
+			settingsRepository.unblock(id)
+		}
+	}
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
@@ -68,37 +68,48 @@ class HomeViewModel @Inject constructor(
 
 	fun deleteFromPool(path: String) {
 		viewModelScope.launch(Dispatchers.IO) {
-			File(path).delete()
+			evictFromPool(path)
+		}
+	}
 
-			val state = stateRepository.state.value
-			val newPaths = state.poolPaths - path
+	fun blockFromPool(id: String, path: String) {
+		viewModelScope.launch(Dispatchers.IO) {
+			settingsRepository.block(id)
+			evictFromPool(path)
+		}
+	}
 
-			val newCurrent = if (state.currentWallpaperPath == path) {
-				newPaths.firstOrNull()
-			} else {
-				state.currentWallpaperPath
-			}
+	private suspend fun evictFromPool(path: String) {
+		File(path).delete()
 
-			val newPrev = if (state.previousWallpaperPath == path) {
-				newPaths.getOrNull(1)
-			} else {
-				state.previousWallpaperPath
-			}
+		val state = stateRepository.state.value
+		val newPaths = state.poolPaths - path
 
-			stateRepository.update {
-				it.copy(
-					poolPaths = newPaths,
-					currentWallpaperPath = newCurrent,
-					previousWallpaperPath = newPrev
-				)
-			}
+		val newCurrent = if (state.currentWallpaperPath == path) {
+			newPaths.firstOrNull()
+		} else {
+			state.currentWallpaperPath
+		}
 
-			settingsRepository.saveServiceState(
-				state.lastUpdatedMs ?: System.currentTimeMillis(),
-				newCurrent,
-				newPrev
+		val newPrev = if (state.previousWallpaperPath == path) {
+			newPaths.getOrNull(1)
+		} else {
+			state.previousWallpaperPath
+		}
+
+		stateRepository.update {
+			it.copy(
+				poolPaths = newPaths,
+				currentWallpaperPath = newCurrent,
+				previousWallpaperPath = newPrev
 			)
 		}
+
+		settingsRepository.saveServiceState(
+			state.lastUpdatedMs ?: System.currentTimeMillis(),
+			newCurrent,
+			newPrev
+		)
 	}
 
 	fun saveToPictures(path: String) {

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/navigation/AppNavigationHost.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import xyz.attacktive.wallhavend.ui.blocklist.BlocklistScreen
 import xyz.attacktive.wallhavend.ui.home.HomeScreen
 import xyz.attacktive.wallhavend.ui.preview.PreviewScreen
 import xyz.attacktive.wallhavend.ui.settings.SettingsScreen
@@ -22,7 +23,14 @@ fun AppNavigationHost(navigationController: NavHostController = rememberNavContr
 		}
 
 		composable("settings") {
-			SettingsScreen(onNavigateBack = { navigationController.popBackStack() })
+			SettingsScreen(
+				onNavigateBack = { navigationController.popBackStack() },
+				onNavigateToBlocklist = { navigationController.navigate("blocklist") }
+			)
+		}
+
+		composable("blocklist") {
+			BlocklistScreen(onNavigateBack = { navigationController.popBackStack() })
 		}
 
 		composable("preview/{id}", arguments = listOf(navArgument("id") { type = NavType.StringType })) { backStackEntry ->

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.OpenInBrowser
@@ -205,6 +206,15 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 					label = stringResource(R.string.preview_action_remove),
 					onClick = {
 						viewModel.deleteFromPool(path)
+						onNavigateBack()
+					}
+				)
+
+				PreviewAction(
+					icon = Icons.Default.Block,
+					label = stringResource(R.string.preview_action_block),
+					onClick = {
+						viewModel.blockFromPool(id, path)
 						onNavigateBack()
 					}
 				)

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -23,6 +24,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.DropdownMenuItem
@@ -57,7 +59,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
@@ -84,11 +88,13 @@ import xyz.attacktive.wallhavend.domain.model.query.ToplistRange
 @Composable
 fun SettingsScreen(
 	onNavigateBack: () -> Unit,
+	onNavigateToBlocklist: () -> Unit,
 	viewModel: SettingsViewModel = hiltViewModel()
 ) {
 	val settings by viewModel.settings.collectAsStateWithLifecycle()
 	val saveError by viewModel.saveError.collectAsStateWithLifecycle()
 	var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+	val scrollState = rememberScrollState()
 
 	val tabs = listOf(
 		stringResource(R.string.settings_tab_content),
@@ -139,22 +145,46 @@ fun SettingsScreen(
 				}
 			}
 
-			Column(
-				modifier = Modifier
-					.fillMaxSize()
-					.verticalScroll(rememberScrollState())
-					.padding(16.dp)
-			) {
-				when (selectedTab) {
-					0 -> ContentTab(settings = settings, onSave = viewModel::save)
-					1 -> ScheduleTab(settings = settings, onSave = viewModel::save)
-					2 -> AdvancedTab(settings = settings, onSave = viewModel::save)
+			Box(modifier = Modifier.weight(1f)) {
+				Column(
+					modifier = Modifier
+						.fillMaxSize()
+						.verticalScroll(scrollState)
+						.padding(16.dp)
+				) {
+					when (selectedTab) {
+						0 -> ContentTab(settings = settings, onSave = viewModel::save, onNavigateToBlocklist = onNavigateToBlocklist)
+						1 -> ScheduleTab(settings = settings, onSave = viewModel::save)
+						2 -> AdvancedTab(settings = settings, onSave = viewModel::save)
+					}
 				}
 
-				Spacer(Modifier.height(24.dp))
+				val scrimAlpha by animateFloatAsState(
+					targetValue = if (scrollState.canScrollForward) {
+						1f
+					} else {
+						0f
+					},
+					label = "footerScrim"
+				)
 
-				val uriHandler = LocalUriHandler.current
+				Box(
+					modifier = Modifier
+						.align(Alignment.BottomCenter)
+						.fillMaxWidth()
+						.height(12.dp)
+						.alpha(scrimAlpha)
+						.background(Brush.verticalGradient(listOf(Color.Transparent, MaterialTheme.colorScheme.surfaceContainerHighest)))
+				)
+			}
 
+			val uriHandler = LocalUriHandler.current
+
+			Column(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(horizontal = 16.dp, vertical = 8.dp)
+			) {
 				Text(
 					text = stringResource(R.string.settings_powered_by),
 					style = MaterialTheme.typography.bodySmall,
@@ -185,7 +215,7 @@ fun SettingsScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
+private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit, onNavigateToBlocklist: () -> Unit) {
 	var searchQuery by rememberSaveable { mutableStateOf(settings.searchQuery) }
 	var filterColor by rememberSaveable { mutableStateOf(settings.filterColor) }
 
@@ -387,6 +417,31 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 		checked = settings.avoidBlurryWallpapers,
 		onToggle = { onSave(settings.copy(avoidBlurryWallpapers = it)) }
 	)
+
+	Spacer(Modifier.height(16.dp))
+
+	Row(
+		verticalAlignment = Alignment.CenterVertically,
+		modifier = Modifier
+			.fillMaxWidth()
+			.clickable { onNavigateToBlocklist() }
+			.padding(vertical = 8.dp)
+	) {
+		Column(modifier = Modifier.weight(1f)) {
+			Text(stringResource(R.string.blocklist_settings_row))
+			Text(
+				stringResource(R.string.blocklist_settings_subtitle, settings.blockedIds.size),
+				style = MaterialTheme.typography.bodySmall,
+				color = MaterialTheme.colorScheme.onSurfaceVariant
+			)
+		}
+
+		Icon(
+			Icons.AutoMirrored.Filled.KeyboardArrowRight,
+			contentDescription = null,
+			tint = MaterialTheme.colorScheme.onSurfaceVariant
+		)
+	}
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,7 +71,15 @@
 	<string name="preview_action_apply">Apply</string>
 	<string name="preview_action_save">Save</string>
 	<string name="preview_action_remove">Remove</string>
+	<string name="preview_action_block">Block</string>
 	<string name="preview_action_open_in_browser">Browser</string>
+	<string name="blocklist_title">Blocked wallpapers</string>
+	<string name="blocklist_settings_row">Blocked wallpapers</string>
+	<string name="blocklist_settings_subtitle">%d hidden from rotation</string>
+	<string name="blocklist_empty">Nothing blocked yet. Block a wallpaper from its preview to hide it from future rotations.</string>
+	<string name="blocklist_unblock">Unblock</string>
+	<string name="blocklist_reveal">Reveal thumbnail</string>
+	<string name="blocklist_open_hint">Tap ID to view on wallhaven.cc</string>
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 hr</string>
 	<string name="settings_unit_hr_plural">%d hr</string>

--- a/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
@@ -89,6 +89,24 @@ class SettingsRepositoryTest {
 	}
 
 	@Test
+	fun `block and unblock round-trip and survive a full settings save`() = runTest {
+		val repository = createRepository()
+		assertTrue(repository.settings.first().blockedIds.isEmpty())
+
+		repository.block("abc123")
+		repository.block("def456")
+		assertEquals(setOf("abc123", "def456"), repository.settings.first { it.blockedIds.size == 2 }.blockedIds)
+
+		repository.save(AppSettings(searchQuery = "marker"))
+
+		val afterSave = repository.settings.first { it.searchQuery == "marker" }
+		assertEquals(setOf("abc123", "def456"), afterSave.blockedIds)
+
+		repository.unblock("abc123")
+		assertEquals(setOf("def456"), repository.settings.first { it.blockedIds == setOf("def456") }.blockedIds)
+	}
+
+	@Test
 	fun `avoidBlurryWallpapers defaults to false and round-trips`() = runTest {
 		val repository = createRepository()
 		assertFalse(repository.settings.first().avoidBlurryWallpapers)

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
@@ -323,6 +323,57 @@ class WallhavenRepositoryTest {
 	}
 
 	@Test
+	fun `next skips blocked ids`() = runTest {
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		val result = repository.next(AppSettings(blockedIds = setOf("w1", "w2")), portraitScreen)
+		assertEquals("w3", result.getOrNull()?.first?.id)
+	}
+
+	@Test
+	fun `next returns NoResultsException when every candidate is blocked`() = runTest {
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
+
+		val result = repository.next(AppSettings(blockedIds = setOf("w1", "w2", "w3")), portraitScreen)
+		assertTrue(result.isFailure)
+		assertTrue(result.exceptionOrNull() is NoResultsException)
+	}
+
+	@Test
+	fun `next advances to the next page when a whole page is blocked`() = runTest {
+		coEvery {
+			wallhavenApiService.search(
+				query = any(), categories = any(), purity = any(), ratios = any(), atleast = any(),
+				sorting = any(), seed = any(), topRange = any(), page = 1, colors = any(), apiKey = any()
+			)
+		} returns makePage(count = 1, currentPage = 1, lastPage = 2)
+
+		coEvery {
+			wallhavenApiService.search(
+				query = any(), categories = any(), purity = any(), ratios = any(), atleast = any(),
+				sorting = any(), seed = any(), topRange = any(), page = 2, colors = any(), apiKey = any()
+			)
+		} returns makePage(count = 1, currentPage = 2, lastPage = 2)
+
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		val result = repository.next(AppSettings(sorting = Sorting.VIEWS, blockedIds = setOf("w-1-1")), portraitScreen)
+		assertEquals("w-2-1", result.getOrNull()?.first?.id)
+
+		coVerify(exactly = 1) {
+			wallhavenApiService.search(
+				query = any(), categories = any(), purity = any(), ratios = any(), atleast = any(),
+				sorting = any(), seed = any(), topRange = any(), page = 2, colors = any(), apiKey = any()
+			)
+		}
+	}
+
+	@Test
 	fun `comma semicolon and pipe delimiters also split the query`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(1)
 		coEvery { fileManager.download(any()) } answers {


### PR DESCRIPTION
## Summary

Adds a local, on-device blocklist (#64) so a wallpaper you never want to see again is never applied. Wallhaven has no per-wallpaper exclusion — verified against the live API — so the filter is client-side.

- **Persist** `blockedIds` in `AppSettings`/DataStore, with atomic `block()`/`unblock()` mutators that bypass the whole-object `save()` so the preview and settings write paths can't clobber each other.
- **Filter** in `WallhavenRepository.next()`: skip blocked IDs at selection, re-fetch the next page when a whole page is blocked (bounded), fall back to `NoResults` when everything is blocked.
- **Block action** in `PreviewScreen` blocks the ID and evicts the file from the pool.
- **Management screen** (`ui/blocklist/`) lists blocked IDs with tap-to-reveal thumbnails — nothing hits the network until you ask, so blocked content isn't re-shown on open — reached from a new row in Settings → Content.

Filtering is global: the background service and interactive paths both go through `next()`, so blocking is enforced everywhere. New unit tests cover skip-blocked / page-advance / all-blocked→`NoResults` and blocklist persistence; full suite is green (34 tests).

## Also included

The Settings footer is now pinned to the bottom with a scroll-aware scrim that fades in only while there's more content below — it previously scrolled away. It's interwoven with the new blocklist row in `SettingsScreen.kt`, hence the same commit.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
