### PR TITLE
feature: replace the current wallpaper right away when it gets blocked

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
 		applicationId = "xyz.attacktive.wallhavend"
 		minSdk = 26
 		targetSdk = 37
-		versionCode = 34
-		versionName = "1.7.1"
+		versionCode = 35
+		versionName = "1.7.2"
 		testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 	}
 

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -73,6 +73,7 @@ class WallpaperService: Service() {
 		when (intent?.action) {
 			ACTION_STOP -> stopSelf()
 			ACTION_UPDATE_NOW -> serviceScope.launch { performUpdate(forceDownload = true) }
+			ACTION_ROLL_NOW -> serviceScope.launch { performUpdate() }
 			ACTION_APPLY_PATH -> {
 				val path = intent.getStringExtra(EXTRA_PATH)
 				if (path != null) {
@@ -352,35 +353,44 @@ class WallpaperService: Service() {
 	companion object {
 		const val ACTION_STOP = "xyz.attacktive.wallhavend.STOP"
 		const val ACTION_UPDATE_NOW = "xyz.attacktive.wallhavend.UPDATE_NOW"
+		const val ACTION_ROLL_NOW = "xyz.attacktive.wallhavend.ROLL_NOW"
 		const val ACTION_APPLY_PATH = "xyz.attacktive.wallhavend.APPLY_PATH"
 		const val EXTRA_PATH = "path"
 
 		fun start(context: Context) {
-			context.startForegroundService(Intent(context, WallpaperService::class.java))
+			val intent = Intent(context, WallpaperService::class.java)
+			context.startForegroundService(intent)
 		}
 
 		fun stop(context: Context) {
-			context.startForegroundService(
-				Intent(context, WallpaperService::class.java)
-					.apply { action = ACTION_STOP }
-			)
+			val intent = Intent(context, WallpaperService::class.java)
+				.apply { action = ACTION_STOP }
+
+			context.startForegroundService(intent)
 		}
 
 		fun updateNow(context: Context) {
-			context.startForegroundService(
-				Intent(context, WallpaperService::class.java)
-					.apply { action = ACTION_UPDATE_NOW }
-			)
+			val intent = Intent(context, WallpaperService::class.java)
+				.apply { action = ACTION_UPDATE_NOW }
+
+			context.startForegroundService(intent)
+		}
+
+		fun rollNow(context: Context) {
+			val intent = Intent(context, WallpaperService::class.java)
+				.apply { action = ACTION_ROLL_NOW }
+
+			context.startForegroundService(intent)
 		}
 
 		fun applyPath(context: Context, path: String) {
-			context.startForegroundService(
-				Intent(context, WallpaperService::class.java)
-					.apply {
-						action = ACTION_APPLY_PATH
-						putExtra(EXTRA_PATH, path)
-					}
-			)
+			val intent = Intent(context, WallpaperService::class.java)
+				.apply {
+					action = ACTION_APPLY_PATH
+					putExtra(EXTRA_PATH, path)
+				}
+
+			context.startForegroundService(intent)
 		}
 	}
 }

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/BlockReplacement.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/BlockReplacement.kt
@@ -1,0 +1,18 @@
+package xyz.attacktive.wallhavend.ui.home
+
+sealed interface BlockReplacement {
+	data object None: BlockReplacement
+	data class ApplyFromPool(val path: String): BlockReplacement
+	data object Roll: BlockReplacement
+}
+
+internal fun blockReplacement(blockedPath: String, currentPath: String?, remainingPool: List<String>): BlockReplacement {
+	if (blockedPath != currentPath) {
+		return BlockReplacement.None
+	}
+
+	return when (val next = remainingPool.firstOrNull()) {
+		null -> BlockReplacement.Roll
+		else -> BlockReplacement.ApplyFromPool(next)
+	}
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
@@ -74,8 +74,15 @@ class HomeViewModel @Inject constructor(
 
 	fun blockFromPool(id: String, path: String) {
 		viewModelScope.launch(Dispatchers.IO) {
+			val currentBeforeBlock = stateRepository.state.value.currentWallpaperPath
 			settingsRepository.block(id)
 			evictFromPool(path)
+
+			when (val replacement = blockReplacement(path, currentBeforeBlock, stateRepository.state.value.poolPaths)) {
+				is BlockReplacement.ApplyFromPool -> WallpaperService.applyPath(context, replacement.path)
+				BlockReplacement.Roll -> WallpaperService.rollNow(context)
+				BlockReplacement.None -> Unit
+			}
 		}
 	}
 

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -86,11 +86,7 @@ import xyz.attacktive.wallhavend.domain.model.query.ToplistRange
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(
-	onNavigateBack: () -> Unit,
-	onNavigateToBlocklist: () -> Unit,
-	viewModel: SettingsViewModel = hiltViewModel()
-) {
+fun SettingsScreen(onNavigateBack: () -> Unit, onNavigateToBlocklist: () -> Unit, viewModel: SettingsViewModel = hiltViewModel()) {
 	val settings by viewModel.settings.collectAsStateWithLifecycle()
 	val saveError by viewModel.saveError.collectAsStateWithLifecycle()
 	var selectedTab by rememberSaveable { mutableIntStateOf(0) }

--- a/app/src/test/java/xyz/attacktive/wallhavend/BlockReplacementTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/BlockReplacementTest.kt
@@ -1,0 +1,52 @@
+package xyz.attacktive.wallhavend
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import xyz.attacktive.wallhavend.ui.home.BlockReplacement
+import xyz.attacktive.wallhavend.ui.home.blockReplacement
+
+class BlockReplacementTest {
+	@Test
+	fun `does nothing when the blocked wallpaper is not the current one`() {
+		val replacement = blockReplacement(
+			blockedPath = "/pool/b.jpg",
+			currentPath = "/pool/a.jpg",
+			remainingPool = listOf("/pool/a.jpg", "/pool/c.jpg")
+		)
+
+		assertEquals(BlockReplacement.None, replacement)
+	}
+
+	@Test
+	fun `does nothing when there is no current wallpaper`() {
+		val replacement = blockReplacement(
+			blockedPath = "/pool/a.jpg",
+			currentPath = null,
+			remainingPool = listOf("/pool/b.jpg")
+		)
+
+		assertEquals(BlockReplacement.None, replacement)
+	}
+
+	@Test
+	fun `applies the most recent remaining pool item when the current wallpaper is blocked`() {
+		val replacement = blockReplacement(
+			blockedPath = "/pool/a.jpg",
+			currentPath = "/pool/a.jpg",
+			remainingPool = listOf("/pool/b.jpg", "/pool/c.jpg")
+		)
+
+		assertEquals(BlockReplacement.ApplyFromPool("/pool/b.jpg"), replacement)
+	}
+
+	@Test
+	fun `rolls when the current wallpaper is blocked and the pool is now empty`() {
+		val replacement = blockReplacement(
+			blockedPath = "/pool/a.jpg",
+			currentPath = "/pool/a.jpg",
+			remainingPool = emptyList()
+		)
+
+		assertEquals(BlockReplacement.Roll, replacement)
+	}
+}


### PR DESCRIPTION
Auto-replace the current wallpaper the moment it's blocked, instead of leaving the just-blocked image on screen until the next scheduled roll.

- Prefer the next item from the local pool — instant and offline-safe.
- Fall back to a non-forcing roll (`ACTION_ROLL_NOW`, respects `wifiOnly`) when the pool is empty.
- Blocking a non-current wallpaper is unchanged.

The replacement decision is unit-tested in `BlockReplacementTest`. Also aligns the service's intent builders into named locals, and bumps the version to 1.7.2 (patch).

Closes #69
