### PR TITLE
fix: persist auto-update intent across process death

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -40,6 +40,7 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 		val LAST_UPDATED_MS = longPreferencesKey("last_updated_ms")
 		val CURRENT_WALLPAPER_PATH = stringPreferencesKey("current_wallpaper_path")
 		val PREVIOUS_WALLPAPER_PATH = stringPreferencesKey("previous_wallpaper_path")
+		val AUTO_UPDATE_ENABLED = booleanPreferencesKey("auto_update_enabled")
 	}
 
 	val settings = dataStore.data
@@ -140,6 +141,16 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 				preferences.remove(Keys.PREVIOUS_WALLPAPER_PATH)
 			}
 		}
+	}
+
+	/**
+	 * Whether the user wants auto-update running. Persisted so the toggle survives process death:
+	 * the in-memory ServiceState.isRunning resets to false whenever the OS reclaims the process.
+	 */
+	suspend fun loadAutoUpdateEnabled() = dataStore.data.first()[Keys.AUTO_UPDATE_ENABLED] ?: false
+
+	suspend fun setAutoUpdateEnabled(enabled: Boolean) {
+		dataStore.edit { preferences -> preferences[Keys.AUTO_UPDATE_ENABLED] = enabled }
 	}
 
 	companion object {

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -71,7 +71,10 @@ class WallpaperService: Service() {
 		startForeground(NOTIFICATION_ID, buildNotification())
 
 		when (intent?.action) {
-			ACTION_STOP -> stopSelf()
+			ACTION_STOP -> serviceScope.launch {
+				settingsRepository.setAutoUpdateEnabled(false)
+				stopSelf()
+			}
 			ACTION_UPDATE_NOW -> serviceScope.launch { performUpdate(forceDownload = true) }
 			ACTION_ROLL_NOW -> serviceScope.launch { performUpdate() }
 			ACTION_APPLY_PATH -> {
@@ -94,7 +97,9 @@ class WallpaperService: Service() {
 		stateRepository.update { it.copy(isRunning = true) }
 
 		timerJob = serviceScope.launch {
+			settingsRepository.setAutoUpdateEnabled(true)
 			runCatching { performUpdate() }
+
 			while (true) {
 				val intervalMs = settingsRepository.settings.first().updateIntervalMinutes * 60_000L
 				delay(intervalMs.milliseconds)

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
@@ -55,6 +55,22 @@ class HomeViewModel @Inject constructor(
 					)
 				}
 			}
+
+			reconcileAutoUpdate()
+		}
+	}
+
+	/**
+	 * A fresh process resets the in-memory running flag to false, so re-derive it from the persisted
+	 * intent and revive the service when the user had auto-update on. The screen is foregrounded when
+	 * this runs, so launching the foreground service is permitted.
+	 */
+	private suspend fun reconcileAutoUpdate() {
+		val enabled = settingsRepository.loadAutoUpdateEnabled()
+		val alreadyRunning = stateRepository.state.value.isRunning
+		if (enabled && !alreadyRunning) {
+			stateRepository.update { it.copy(isRunning = true) }
+			WallpaperService.start(context)
 		}
 	}
 

--- a/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
@@ -1,6 +1,10 @@
 package xyz.attacktive.wallhavend
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.job
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
@@ -115,5 +119,33 @@ class SettingsRepositoryTest {
 
 		val loaded = repository.settings.first { it.searchQuery == "marker" }
 		assertTrue(loaded.avoidBlurryWallpapers)
+	}
+
+	@Test
+	fun `auto-update enabled defaults to false`() = runTest {
+		val repository = createRepository()
+		assertFalse(repository.loadAutoUpdateEnabled())
+	}
+
+	@Test
+	fun `auto-update enabled survives a process restart`() = runTest {
+		val file = tmpFolder.newFile("intent_prefs.preferences_pb")
+
+		val firstScope = CoroutineScope(backgroundScope.coroutineContext + Job())
+		val firstProcess = SettingsRepository(
+			PreferenceDataStoreFactory.create(scope = firstScope, produceFile = { file }),
+			FakeAppLogger()
+		)
+
+		firstProcess.setAutoUpdateEnabled(true)
+		// Tearing down the DataStore's scope releases the file, simulating the OS killing the process.
+		firstScope.coroutineContext.job.cancelAndJoin()
+
+		val secondProcess = SettingsRepository(
+			PreferenceDataStoreFactory.create(scope = backgroundScope, produceFile = { file }),
+			FakeAppLogger()
+		)
+
+		assertTrue(secondProcess.loadAutoUpdateEnabled())
 	}
 }


### PR DESCRIPTION
The auto-update toggle could turn itself off. Its on/off state lived only in the in-memory `ServiceState.isRunning` singleton, so an OS process kill reset it to `false` and resuming relied entirely on `START_STICKY`'s restart — which One UI does not reliably honor. The service stayed dead and the toggle showed off until the user tapped Start again.

This persists the intent to DataStore (`auto_update_enabled`): `true` when the timer loop starts, `false` on an explicit Stop. On Home `ViewModel` creation it reconciles the in-memory flag from the persisted intent and revives the service when it should be running — the screen is foregrounded then, so the foreground-service start is allowed.

**Trade-off / known limitation:** reconciliation runs on `ViewModel` creation (a fresh open), not on a warm resume where the `ViewModel` already exists. On an existing install the flag isn't persisted until the loop runs once after updating. In both cases the worst case is simply the previous behavior, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
