### PR TITLE
feature: pin wallpapers and add rotation mode picker

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
@@ -12,7 +12,7 @@ data class AppSettings(
 	val purity: Set<Purity> = setOf(Purity.SFW),
 	val updateIntervalMinutes: Int = 60,
 	val wallpaperTarget: WallpaperTarget = WallpaperTarget.HOME,
-	val wifiOnly: Boolean = true,
+	val rotationMode: RotationMode = RotationMode.FRESH_WIFI,
 	val poolSize: Int = 10,
 	val apiKey: String = "",
 	val autoStartOnBoot: Boolean = true,
@@ -20,7 +20,8 @@ data class AppSettings(
 	val sorting: Sorting = Sorting.RANDOM,
 	val toplistRange: ToplistRange = ToplistRange.ONE_MONTH,
 	val avoidBlurryWallpapers: Boolean = false,
-	val blockedIds: Set<String> = emptySet()
+	val blockedIds: Set<String> = emptySet(),
+	val pinnedIds: Set<String> = emptySet()
 )
 
 val UPDATE_INTERVAL_OPTIONS = listOf(1, 5, 15, 30, 60, 180, 360, 1440)

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/RotationMode.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/RotationMode.kt
@@ -1,0 +1,3 @@
+package xyz.attacktive.wallhavend.domain.model
+
+enum class RotationMode { FRESH_ANY, FRESH_WIFI, PINNED_ONLY }

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -13,6 +13,7 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import xyz.attacktive.wallhavend.domain.model.AppSettings
+import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.query.Category
 import xyz.attacktive.wallhavend.domain.model.query.Purity
@@ -28,7 +29,10 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 		val PURITY = stringSetPreferencesKey("purity")
 		val UPDATE_INTERVAL_MINUTES = intPreferencesKey("update_interval_minutes")
 		val WALLPAPER_TARGET = stringPreferencesKey("wallpaper_target")
+
+		// Retained read-only so installs predating the rotation-mode picker can migrate; never written anymore.
 		val WIFI_ONLY = booleanPreferencesKey("wifi_only")
+		val ROTATION_MODE = stringPreferencesKey("rotation_mode")
 		val POOL_SIZE = intPreferencesKey("pool_size")
 		val API_KEY = stringPreferencesKey("api_key")
 		val AUTO_START_ON_BOOT = booleanPreferencesKey("auto_start_on_boot")
@@ -37,6 +41,7 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 		val TOPLIST_RANGE = stringPreferencesKey("toplist_range")
 		val AVOID_BLURRY_WALLPAPERS = booleanPreferencesKey("avoid_blurry_wallpapers")
 		val BLOCKED_IDS = stringSetPreferencesKey("blocked_ids")
+		val PINNED_IDS = stringSetPreferencesKey("pinned_ids")
 		val LAST_UPDATED_MS = longPreferencesKey("last_updated_ms")
 		val CURRENT_WALLPAPER_PATH = stringPreferencesKey("current_wallpaper_path")
 		val PREVIOUS_WALLPAPER_PATH = stringPreferencesKey("previous_wallpaper_path")
@@ -58,7 +63,9 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 				wallpaperTarget = preferences[Keys.WALLPAPER_TARGET]
 					?.let { runCatching { WallpaperTarget.valueOf(it) }.getOrNull() }
 					?: WallpaperTarget.HOME,
-				wifiOnly = preferences[Keys.WIFI_ONLY] ?: true,
+				rotationMode = preferences[Keys.ROTATION_MODE]
+					?.let { runCatching { RotationMode.valueOf(it) }.getOrNull() }
+					?: migrateRotationMode(preferences[Keys.WIFI_ONLY]),
 				poolSize = preferences[Keys.POOL_SIZE] ?: 10,
 				apiKey = preferences[Keys.API_KEY] ?: "",
 				autoStartOnBoot = preferences[Keys.AUTO_START_ON_BOOT] ?: true,
@@ -66,7 +73,8 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 				sorting = Sorting.fromApiValue(preferences[Keys.SORTING] ?: "random"),
 				toplistRange = ToplistRange.fromApiValue(preferences[Keys.TOPLIST_RANGE] ?: "1M"),
 				avoidBlurryWallpapers = preferences[Keys.AVOID_BLURRY_WALLPAPERS] ?: false,
-				blockedIds = preferences[Keys.BLOCKED_IDS] ?: emptySet()
+				blockedIds = preferences[Keys.BLOCKED_IDS] ?: emptySet(),
+				pinnedIds = preferences[Keys.PINNED_IDS] ?: emptySet()
 			)
 			.also { logger.debug(TAG, "read: ${it.redactedForLog()}") }
 		}
@@ -87,7 +95,7 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 
 			preferences[Keys.UPDATE_INTERVAL_MINUTES] = settings.updateIntervalMinutes
 			preferences[Keys.WALLPAPER_TARGET] = settings.wallpaperTarget.name
-			preferences[Keys.WIFI_ONLY] = settings.wifiOnly
+			preferences[Keys.ROTATION_MODE] = settings.rotationMode.name
 			preferences[Keys.POOL_SIZE] = settings.poolSize
 			preferences[Keys.API_KEY] = settings.apiKey
 			preferences[Keys.AUTO_START_ON_BOOT] = settings.autoStartOnBoot
@@ -114,6 +122,19 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 	suspend fun unblock(id: String) {
 		dataStore.edit { preferences ->
 			preferences[Keys.BLOCKED_IDS] = (preferences[Keys.BLOCKED_IDS] ?: emptySet()) - id
+		}
+	}
+
+	/* Same isolation rationale as block/unblock: the pin set grows from the preview screen, so it gets its own key that save() leaves untouched. */
+	suspend fun pin(id: String) {
+		dataStore.edit { preferences ->
+			preferences[Keys.PINNED_IDS] = (preferences[Keys.PINNED_IDS] ?: emptySet()) + id
+		}
+	}
+
+	suspend fun unpin(id: String) {
+		dataStore.edit { preferences ->
+			preferences[Keys.PINNED_IDS] = (preferences[Keys.PINNED_IDS] ?: emptySet()) - id
 		}
 	}
 
@@ -157,6 +178,14 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 		private const val TAG = "SettingsRepository"
 	}
 }
+
+/** Maps the pre-rotation-mode `wifi_only` flag onto its equivalent mode for installs that predate the picker. */
+private fun migrateRotationMode(wifiOnly: Boolean?) =
+	if (wifiOnly == false) {
+		RotationMode.FRESH_ANY
+	} else {
+		RotationMode.FRESH_WIFI
+	}
 
 /** Renders settings for logging without exposing the API key. */
 private fun AppSettings.redactedForLog(): AppSettings =

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/RotationDecisions.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/RotationDecisions.kt
@@ -1,0 +1,31 @@
+package xyz.attacktive.wallhavend.domain.service
+
+import xyz.attacktive.wallhavend.domain.model.RotationMode
+
+/**
+ * Whether the next rotation tick should fetch a fresh wallpaper rather than cycle the pool.
+ * Downloading always requires connectivity; a forced request (the "Download now" button) overrides
+ * the per-mode network rules but still cannot beat being offline.
+ */
+fun shouldDownload(mode: RotationMode, online: Boolean, onWifi: Boolean, forceDownload: Boolean): Boolean {
+	if (!online) {
+		return false
+	}
+
+	if (forceDownload) {
+		return true
+	}
+
+	return when (mode) {
+		RotationMode.FRESH_ANY -> true
+		RotationMode.FRESH_WIFI -> onWifi
+		RotationMode.PINNED_ONLY -> false
+	}
+}
+
+/** The next path in a wrap-around ring walk, or null when the pool is empty. */
+fun nextInCycle(pool: List<String>, current: String?): String? {
+	val currentIndex = current?.let { pool.indexOf(it) } ?: -1
+
+	return pool.getOrNull(currentIndex + 1) ?: pool.firstOrNull()
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperFileManager.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperFileManager.kt
@@ -42,13 +42,13 @@ class WallpaperFileManager(private val wallpaperDir: File, private val okHttpCli
 
 	fun listAll() = sortedFiles()
 
-	fun trimToSize(maxSize: Int): List<File> {
-		val all = sortedFiles()
+	fun trimToSize(maxSize: Int, pinnedIds: Set<String> = emptySet()): List<File> {
+		val (pinned, rotating) = sortedFiles().partition { it.nameWithoutExtension in pinnedIds }
 
-		all.drop(maxSize)
+		rotating.drop(maxSize)
 			.forEach { it.delete() }
 
-		return all.take(maxSize)
+		return (pinned + rotating.take(maxSize)).sortedByDescending { it.lastModified() }
 	}
 
 	private fun sortedFiles() =

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -37,6 +37,7 @@ import xyz.attacktive.wallhavend.WallhavendApplication.Companion.NOTIFICATION_ID
 import xyz.attacktive.wallhavend.domain.model.AppError
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.NoResultsException
+import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.ScreenInfo
 import xyz.attacktive.wallhavend.domain.model.UnsupportedFormatException
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
@@ -116,9 +117,11 @@ class WallpaperService: Service() {
 		stateRepository.update { it.copy(isOnline = online) }
 
 		val onWifi = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
-		val canDownload = online && (forceDownload || !settings.wifiOnly || onWifi)
-		if (canDownload) {
+
+		if (shouldDownload(settings.rotationMode, online, onWifi, forceDownload)) {
 			handleOnlineUpdate(settings)
+		} else if (settings.rotationMode == RotationMode.PINNED_ONLY) {
+			cyclePinnedOnly(settings)
 		} else {
 			cycleFromPool(settings)
 		}
@@ -136,7 +139,7 @@ class WallpaperService: Service() {
 		applyWallpaper(file, settings.wallpaperTarget)
 			.fold(
 				onSuccess = {
-					val remaining = fileManager.trimToSize(settings.poolSize)
+					val remaining = fileManager.trimToSize(settings.poolSize, settings.pinnedIds)
 					val paths = remaining.map { it.absolutePath }
 					val now = System.currentTimeMillis()
 
@@ -176,21 +179,24 @@ class WallpaperService: Service() {
 	}
 
 	private suspend fun cycleFromPool(settings: AppSettings) {
-		val current = stateRepository.state.value.currentWallpaperPath
-
 		val pool = fileManager.listAll()
 			.reversed()
 			.map { it.absolutePath }
 
-		val currentIndex = if (current != null) {
-			pool.indexOf(current)
-		} else {
-			-1
-		}
+		cycle(pool, settings)
+	}
 
-		val next = pool.getOrNull(currentIndex + 1)
-			?: pool.firstOrNull()
-			?: return
+	private suspend fun cyclePinnedOnly(settings: AppSettings) {
+		val pool = fileManager.listAll()
+			.filter { it.nameWithoutExtension in settings.pinnedIds }
+			.reversed()
+			.map { it.absolutePath }
+
+		cycle(pool, settings)
+	}
+
+	private suspend fun cycle(pool: List<String>, settings: AppSettings) {
+		val next = nextInCycle(pool, stateRepository.state.value.currentWallpaperPath) ?: return
 
 		val file = File(next)
 		if (!file.exists()) {

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
@@ -4,6 +4,7 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -17,14 +18,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.Button
@@ -58,6 +62,7 @@ import xyz.attacktive.wallhavend.domain.model.ServiceState
 @Composable
 fun HomeScreen(onNavigateToSettings: () -> Unit, onNavigateToPreview: (String) -> Unit, viewModel: HomeViewModel = hiltViewModel()) {
 	val state by viewModel.serviceState.collectAsStateWithLifecycle()
+	val pinnedIds by viewModel.pinnedIds.collectAsStateWithLifecycle()
 
 	Scaffold(
 		topBar = {
@@ -111,6 +116,7 @@ fun HomeScreen(onNavigateToSettings: () -> Unit, onNavigateToPreview: (String) -
 				WallpaperGrid(
 					paths = state.poolPaths,
 					currentPath = state.currentWallpaperPath,
+					pinnedIds = pinnedIds,
 					onTap = { path -> onNavigateToPreview(File(path).nameWithoutExtension) }
 				)
 			}
@@ -173,7 +179,7 @@ private fun QuickActions(state: ServiceState, onStartStop: () -> Unit, onUpdateN
 }
 
 @Composable
-private fun WallpaperGrid(paths: List<String>, currentPath: String?, onTap: (String) -> Unit) {
+private fun WallpaperGrid(paths: List<String>, currentPath: String?, pinnedIds: Set<String>, onTap: (String) -> Unit) {
 	LazyVerticalGrid(
 		columns = GridCells.Fixed(3),
 		contentPadding = PaddingValues(vertical = 4.dp),
@@ -182,6 +188,7 @@ private fun WallpaperGrid(paths: List<String>, currentPath: String?, onTap: (Str
 	) {
 		items(paths) { path ->
 			val isCurrent = path == currentPath
+			val isPinned = File(path).nameWithoutExtension in pinnedIds
 
 			Box(
 				modifier = Modifier
@@ -205,6 +212,25 @@ private fun WallpaperGrid(paths: List<String>, currentPath: String?, onTap: (Str
 					contentScale = ContentScale.Crop,
 					modifier = Modifier.fillMaxSize()
 				)
+
+				if (isPinned) {
+					Box(
+						contentAlignment = Alignment.Center,
+						modifier = Modifier
+							.align(Alignment.TopEnd)
+							.padding(4.dp)
+							.size(18.dp)
+							.clip(CircleShape)
+							.background(MaterialTheme.colorScheme.primary)
+					) {
+						Icon(
+							Icons.Default.PushPin,
+							contentDescription = stringResource(R.string.cd_pinned),
+							tint = MaterialTheme.colorScheme.onPrimary,
+							modifier = Modifier.size(12.dp)
+						)
+					}
+				}
 			}
 		}
 	}

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import android.content.ContentValues
@@ -34,6 +35,10 @@ class HomeViewModel @Inject constructor(
 ): ViewModel() {
 	val serviceState = stateRepository.state
 		.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ServiceState())
+
+	val pinnedIds = settingsRepository.settings
+		.map { it.pinnedIds }
+		.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
 
 	private val _saveMessage = MutableSharedFlow<String>(extraBufferCapacity = 1)
 	val saveMessage = _saveMessage.asSharedFlow()
@@ -82,6 +87,16 @@ class HomeViewModel @Inject constructor(
 		WallpaperService.applyPath(context, path)
 	}
 
+	fun togglePin(id: String) {
+		viewModelScope.launch(Dispatchers.IO) {
+			if (id in pinnedIds.value) {
+				settingsRepository.unpin(id)
+			} else {
+				settingsRepository.pin(id)
+			}
+		}
+	}
+
 	fun deleteFromPool(path: String) {
 		viewModelScope.launch(Dispatchers.IO) {
 			evictFromPool(path)
@@ -103,7 +118,9 @@ class HomeViewModel @Inject constructor(
 	}
 
 	private suspend fun evictFromPool(path: String) {
-		File(path).delete()
+		val file = File(path)
+		settingsRepository.unpin(file.nameWithoutExtension)
+		file.delete()
 
 		val state = stateRepository.state.value
 		val newPaths = state.poolPaths - path

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
@@ -35,7 +35,9 @@ import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.OpenInBrowser
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Wallpaper
+import androidx.compose.material.icons.outlined.PushPin as PushPinOutlined
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -66,6 +68,7 @@ import xyz.attacktive.wallhavend.ui.home.HomeViewModel
 @Composable
 fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewModel = hiltViewModel()) {
 	val state by viewModel.serviceState.collectAsStateWithLifecycle()
+	val pinnedIds by viewModel.pinnedIds.collectAsStateWithLifecycle()
 	val context = LocalContext.current
 	val path = remember(state.poolPaths, id) {
 		state.poolPaths.firstOrNull { File(it).nameWithoutExtension == id }
@@ -199,6 +202,18 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 							writePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
 						}
 					}
+				)
+
+				val isPinned = id in pinnedIds
+
+				PreviewAction(
+					icon = if (isPinned) {
+						Icons.Default.PushPin
+					} else {
+						Icons.Outlined.PushPinOutlined
+					},
+					label = stringResource(if (isPinned) { R.string.preview_action_unpin } else { R.string.preview_action_pin }),
+					onClick = { viewModel.togglePin(id) }
 				)
 
 				PreviewAction(

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
@@ -192,18 +192,6 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 					}
 				)
 
-				PreviewAction(
-					icon = Icons.Default.Download,
-					label = stringResource(R.string.preview_action_save),
-					onClick = {
-						if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-							viewModel.saveToPictures(path)
-						} else {
-							writePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-						}
-					}
-				)
-
 				val isPinned = id in pinnedIds
 
 				PreviewAction(
@@ -214,6 +202,18 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 					},
 					label = stringResource(if (isPinned) { R.string.preview_action_unpin } else { R.string.preview_action_pin }),
 					onClick = { viewModel.togglePin(id) }
+				)
+
+				PreviewAction(
+					icon = Icons.Default.Download,
+					label = stringResource(R.string.preview_action_save),
+					onClick = {
+						if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+							viewModel.saveToPictures(path)
+						} else {
+							writePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+						}
+					}
 				)
 
 				PreviewAction(

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -77,6 +77,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import xyz.attacktive.wallhavend.R
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.POOL_SIZE_OPTIONS
+import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.UPDATE_INTERVAL_OPTIONS
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.query.Category
@@ -507,13 +508,44 @@ private fun ScheduleTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 	}
 
 	Spacer(Modifier.height(16.dp))
+	SectionLabel(stringResource(R.string.settings_label_rotation_mode))
 
-	ToggleSetting(
-		label = stringResource(R.string.settings_label_wifi_only),
-		subtitle = stringResource(R.string.settings_subtitle_wifi_only),
-		checked = settings.wifiOnly,
-		onToggle = { onSave(settings.copy(wifiOnly = it)) }
-	)
+	RotationMode.entries.forEach { mode ->
+		val enabled = mode != RotationMode.PINNED_ONLY || settings.pinnedIds.isNotEmpty()
+
+		Row(
+			verticalAlignment = Alignment.CenterVertically,
+			modifier = Modifier
+				.fillMaxWidth()
+				.alpha(if (enabled) { 1f } else { 0.38f })
+				.clickable(enabled = enabled) { onSave(settings.copy(rotationMode = mode)) }
+		) {
+			RadioButton(selected = settings.rotationMode == mode, onClick = null, enabled = enabled)
+
+			Column(modifier = Modifier.padding(start = 4.dp)) {
+				Text(
+					text = when (mode) {
+						RotationMode.FRESH_ANY -> stringResource(R.string.settings_rotation_fresh_any)
+						RotationMode.FRESH_WIFI -> stringResource(R.string.settings_rotation_fresh_wifi)
+						RotationMode.PINNED_ONLY -> stringResource(R.string.settings_rotation_pinned_only)
+					}
+				)
+
+				val description = when {
+					!enabled -> stringResource(R.string.settings_rotation_pinned_disabled_hint)
+					mode == RotationMode.FRESH_ANY -> stringResource(R.string.settings_rotation_fresh_any_desc)
+					mode == RotationMode.FRESH_WIFI -> stringResource(R.string.settings_rotation_fresh_wifi_desc)
+					else -> stringResource(R.string.settings_rotation_pinned_only_desc)
+				}
+
+				Text(
+					text = description,
+					style = MaterialTheme.typography.bodySmall,
+					color = MaterialTheme.colorScheme.onSurfaceVariant
+				)
+			}
+		}
+	}
 
 	Spacer(Modifier.height(8.dp))
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -25,8 +25,14 @@
 	<string name="settings_target_home">Nur Startbildschirm</string>
 	<string name="settings_target_lock">Nur Sperrbildschirm</string>
 	<string name="settings_target_both">Beide</string>
-	<string name="settings_label_wifi_only">Nur WLAN</string>
-	<string name="settings_subtitle_wifi_only">Updates bei mobilen Daten überspringen</string>
+	<string name="settings_label_rotation_mode">ROTATIONSMODUS</string>
+	<string name="settings_rotation_fresh_any">Neu — beliebiges Netzwerk</string>
+	<string name="settings_rotation_fresh_any_desc">Ein neues Hintergrundbild über jede Verbindung herunterladen</string>
+	<string name="settings_rotation_fresh_wifi">Neu — nur WLAN</string>
+	<string name="settings_rotation_fresh_wifi_desc">Im WLAN neu herunterladen; bei mobilen Daten gespeicherte Hintergründe durchwechseln</string>
+	<string name="settings_rotation_pinned_only">Nur angeheftete</string>
+	<string name="settings_rotation_pinned_only_desc">Nur deine angehefteten Hintergrundbilder durchwechseln</string>
+	<string name="settings_rotation_pinned_disabled_hint">Hefte mindestens ein Hintergrundbild an, um diesen Modus zu nutzen</string>
 	<string name="settings_label_auto_start">Automatischer Start beim Booten</string>
 	<string name="settings_subtitle_auto_start">Kein Root erforderlich</string>
 	<string name="settings_label_pool_size">POOL-GRÖSSE</string>
@@ -52,6 +58,7 @@
 	<string name="cd_save_to_pictures">In Bildern speichern</string>
 	<string name="cd_delete">Löschen</string>
 	<string name="cd_back">Zurück</string>
+	<string name="cd_pinned">Angeheftet</string>
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 Std.</string>
 	<string name="settings_unit_hr_plural">%d Std.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -25,8 +25,14 @@
 	<string name="settings_target_home">Solo pantalla de inicio</string>
 	<string name="settings_target_lock">Solo pantalla de bloqueo</string>
 	<string name="settings_target_both">Ambas</string>
-	<string name="settings_label_wifi_only">Solo Wi-Fi</string>
-	<string name="settings_subtitle_wifi_only">Omitir actualizaciones con datos móviles</string>
+	<string name="settings_label_rotation_mode">MODO DE ROTACIÓN</string>
+	<string name="settings_rotation_fresh_any">Nuevo — cualquier red</string>
+	<string name="settings_rotation_fresh_any_desc">Descargar un nuevo fondo de pantalla en cualquier conexión</string>
+	<string name="settings_rotation_fresh_wifi">Nuevo — solo Wi-Fi</string>
+	<string name="settings_rotation_fresh_wifi_desc">Descargar con Wi-Fi; rotar los fondos guardados con datos móviles</string>
+	<string name="settings_rotation_pinned_only">Solo fijados</string>
+	<string name="settings_rotation_pinned_only_desc">Rotar solo tus fondos de pantalla fijados</string>
+	<string name="settings_rotation_pinned_disabled_hint">Fija al menos un fondo de pantalla para usar este modo</string>
 	<string name="settings_label_auto_start">Inicio automático al arrancar</string>
 	<string name="settings_subtitle_auto_start">No se requiere root</string>
 	<string name="settings_label_pool_size">TAMAÑO DEL DEPÓSITO DE FONDOS</string>
@@ -52,6 +58,7 @@
 	<string name="cd_save_to_pictures">Guardar en Imágenes</string>
 	<string name="cd_delete">Eliminar</string>
 	<string name="cd_back">Atrás</string>
+	<string name="cd_pinned">Fijado</string>
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 h</string>
 	<string name="settings_unit_hr_plural">%d h</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -25,8 +25,14 @@
 	<string name="settings_target_home">Écran d\'accueil uniquement</string>
 	<string name="settings_target_lock">Écran de verrouillage uniquement</string>
 	<string name="settings_target_both">Les deux</string>
-	<string name="settings_label_wifi_only">Wi-Fi uniquement</string>
-	<string name="settings_subtitle_wifi_only">Passer les mises à jour sur données mobiles</string>
+	<string name="settings_label_rotation_mode">MODE DE ROTATION</string>
+	<string name="settings_rotation_fresh_any">Nouveau — tout réseau</string>
+	<string name="settings_rotation_fresh_any_desc">Télécharger un nouveau fond d\'écran sur toute connexion</string>
+	<string name="settings_rotation_fresh_wifi">Nouveau — Wi-Fi uniquement</string>
+	<string name="settings_rotation_fresh_wifi_desc">Télécharger en Wi-Fi ; faire défiler les fonds enregistrés en données mobiles</string>
+	<string name="settings_rotation_pinned_only">Épinglés uniquement</string>
+	<string name="settings_rotation_pinned_only_desc">Faire défiler uniquement vos fonds d\'écran épinglés</string>
+	<string name="settings_rotation_pinned_disabled_hint">Épinglez au moins un fond d\'écran pour utiliser ce mode</string>
 	<string name="settings_label_auto_start">Démarrage auto au boot</string>
 	<string name="settings_subtitle_auto_start">Pas besoin de root</string>
 	<string name="settings_label_pool_size">TAILLE DE LA RÉSERVE</string>
@@ -52,6 +58,7 @@
 	<string name="cd_save_to_pictures">Enregistrer dans Images</string>
 	<string name="cd_delete">Supprimer</string>
 	<string name="cd_back">Retour</string>
+	<string name="cd_pinned">Épinglé</string>
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 h</string>
 	<string name="settings_unit_hr_plural">%d h</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -25,8 +25,14 @@
 	<string name="settings_target_home">ホーム画面のみ</string>
 	<string name="settings_target_lock">ロック画面のみ</string>
 	<string name="settings_target_both">両方</string>
-	<string name="settings_label_wifi_only">Wi-Fiのみ</string>
-	<string name="settings_subtitle_wifi_only">モバイルデータ通信時は更新をスキップ</string>
+	<string name="settings_label_rotation_mode">ローテーションモード</string>
+	<string name="settings_rotation_fresh_any">新規取得 — すべてのネットワーク</string>
+	<string name="settings_rotation_fresh_any_desc">どの接続でも新しい壁紙をダウンロードします</string>
+	<string name="settings_rotation_fresh_wifi">新規取得 — Wi-Fiのみ</string>
+	<string name="settings_rotation_fresh_wifi_desc">Wi-Fiでは新しくダウンロードし、モバイルデータでは保存済みの壁紙を切り替えます</string>
+	<string name="settings_rotation_pinned_only">ピン留めのみ</string>
+	<string name="settings_rotation_pinned_only_desc">ピン留めした壁紙のみを切り替えます</string>
+	<string name="settings_rotation_pinned_disabled_hint">このモードを使うには壁紙を1枚以上ピン留めしてください</string>
 	<string name="settings_label_auto_start">起動時に自動開始</string>
 	<string name="settings_subtitle_auto_start">Root権限は不要です</string>
 	<string name="settings_label_pool_size">壁紙プールのサイズ</string>
@@ -52,6 +58,7 @@
 	<string name="cd_save_to_pictures">ピクチャに保存</string>
 	<string name="cd_delete">削除</string>
 	<string name="cd_back">戻る</string>
+	<string name="cd_pinned">ピン留め</string>
 	<string name="settings_unit_min">%d分</string>
 	<string name="settings_unit_hr_single">1時間</string>
 	<string name="settings_unit_hr_plural">%d時間</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -25,8 +25,14 @@
 	<string name="settings_target_home">홈 화면만</string>
 	<string name="settings_target_lock">잠금 화면만</string>
 	<string name="settings_target_both">둘 다</string>
-	<string name="settings_label_wifi_only">Wi-Fi 전용</string>
-	<string name="settings_subtitle_wifi_only">모바일 데이터 사용 시 업데이트 건너뛰기</string>
+	<string name="settings_label_rotation_mode">순환 모드</string>
+	<string name="settings_rotation_fresh_any">새로 받기 — 모든 네트워크</string>
+	<string name="settings_rotation_fresh_any_desc">모든 연결에서 새 배경화면을 다운로드합니다</string>
+	<string name="settings_rotation_fresh_wifi">새로 받기 — Wi-Fi 전용</string>
+	<string name="settings_rotation_fresh_wifi_desc">Wi-Fi에서는 새로 다운로드하고, 모바일 데이터에서는 저장된 배경화면을 순환합니다</string>
+	<string name="settings_rotation_pinned_only">고정된 항목만</string>
+	<string name="settings_rotation_pinned_only_desc">고정한 배경화면만 순환합니다</string>
+	<string name="settings_rotation_pinned_disabled_hint">이 모드를 사용하려면 배경화면을 하나 이상 고정하세요</string>
 	<string name="settings_label_auto_start">부팅 시 자동 시작</string>
 	<string name="settings_subtitle_auto_start">루트 권한이 필요하지 않습니다</string>
 	<string name="settings_label_pool_size">배경화면 풀 크기</string>
@@ -52,6 +58,7 @@
 	<string name="cd_save_to_pictures">사진 폴더에 저장</string>
 	<string name="cd_delete">삭제</string>
 	<string name="cd_back">뒤로</string>
+	<string name="cd_pinned">고정</string>
 	<string name="settings_unit_min">%d분</string>
 	<string name="settings_unit_hr_single">1시간</string>
 	<string name="settings_unit_hr_plural">%d시간</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -25,8 +25,14 @@
 	<string name="settings_target_home">Apenas tela inicial</string>
 	<string name="settings_target_lock">Apenas tela de bloqueio</string>
 	<string name="settings_target_both">Ambas</string>
-	<string name="settings_label_wifi_only">Apenas Wi-Fi</string>
-	<string name="settings_subtitle_wifi_only">Pular atualizações em dados móveis</string>
+	<string name="settings_label_rotation_mode">MODO DE ROTAÇÃO</string>
+	<string name="settings_rotation_fresh_any">Novo — qualquer rede</string>
+	<string name="settings_rotation_fresh_any_desc">Baixar um novo papel de parede em qualquer conexão</string>
+	<string name="settings_rotation_fresh_wifi">Novo — somente Wi-Fi</string>
+	<string name="settings_rotation_fresh_wifi_desc">Baixar no Wi-Fi; alternar os papéis salvos em dados móveis</string>
+	<string name="settings_rotation_pinned_only">Somente fixados</string>
+	<string name="settings_rotation_pinned_only_desc">Alternar apenas os seus papéis de parede fixados</string>
+	<string name="settings_rotation_pinned_disabled_hint">Fixe pelo menos um papel de parede para usar este modo</string>
 	<string name="settings_label_auto_start">Iniciar com o sistema</string>
 	<string name="settings_subtitle_auto_start">Não requer root</string>
 	<string name="settings_label_pool_size">TAMANHO DA GALERIA</string>
@@ -52,6 +58,7 @@
 	<string name="cd_save_to_pictures">Salvar em Imagens</string>
 	<string name="cd_delete">Excluir</string>
 	<string name="cd_back">Voltar</string>
+	<string name="cd_pinned">Fixado</string>
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 h</string>
 	<string name="settings_unit_hr_plural">%d h</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -25,8 +25,14 @@
 	<string name="settings_target_home">仅主屏幕</string>
 	<string name="settings_target_lock">仅锁屏</string>
 	<string name="settings_target_both">主屏幕与锁屏</string>
-	<string name="settings_label_wifi_only">仅限 Wi-Fi</string>
-	<string name="settings_subtitle_wifi_only">使用移动数据时跳过更新</string>
+	<string name="settings_label_rotation_mode">轮换模式</string>
+	<string name="settings_rotation_fresh_any">获取新图 — 任意网络</string>
+	<string name="settings_rotation_fresh_any_desc">在任意连接下下载新壁纸</string>
+	<string name="settings_rotation_fresh_wifi">获取新图 — 仅 Wi-Fi</string>
+	<string name="settings_rotation_fresh_wifi_desc">在 Wi-Fi 下下载新壁纸；使用移动数据时轮换已保存的壁纸</string>
+	<string name="settings_rotation_pinned_only">仅置顶</string>
+	<string name="settings_rotation_pinned_only_desc">仅轮换您置顶的壁纸</string>
+	<string name="settings_rotation_pinned_disabled_hint">置顶至少一张壁纸后才能使用此模式</string>
 	<string name="settings_label_auto_start">开机自启动</string>
 	<string name="settings_subtitle_auto_start">无需 Root 权限</string>
 	<string name="settings_label_pool_size">壁纸缓存数量</string>
@@ -52,6 +58,7 @@
 	<string name="cd_save_to_pictures">保存至相册</string>
 	<string name="cd_delete">删除</string>
 	<string name="cd_back">返回</string>
+	<string name="cd_pinned">已置顶</string>
 	<string name="settings_unit_min">%d 分钟</string>
 	<string name="settings_unit_hr_single">1 小时</string>
 	<string name="settings_unit_hr_plural">%d 小时</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,8 +41,14 @@
 	<string name="settings_target_home">Home screen only</string>
 	<string name="settings_target_lock">Lock screen only</string>
 	<string name="settings_target_both">Both</string>
-	<string name="settings_label_wifi_only">Wi-Fi only</string>
-	<string name="settings_subtitle_wifi_only">Skip updates on mobile data</string>
+	<string name="settings_label_rotation_mode">ROTATION MODE</string>
+	<string name="settings_rotation_fresh_any">Fresh — any network</string>
+	<string name="settings_rotation_fresh_any_desc">Download a new wallpaper on any connection</string>
+	<string name="settings_rotation_fresh_wifi">Fresh — Wi-Fi only</string>
+	<string name="settings_rotation_fresh_wifi_desc">Download on Wi-Fi; cycle saved wallpapers on mobile data</string>
+	<string name="settings_rotation_pinned_only">Pinned only</string>
+	<string name="settings_rotation_pinned_only_desc">Cycle only your pinned wallpapers</string>
+	<string name="settings_rotation_pinned_disabled_hint">Pin at least one wallpaper to use this</string>
 	<string name="settings_label_auto_start">Auto-start on boot</string>
 	<string name="settings_subtitle_auto_start">No root required</string>
 	<string name="settings_label_pool_size">WALLPAPER POOL SIZE</string>
@@ -72,7 +78,10 @@
 	<string name="preview_action_save">Save</string>
 	<string name="preview_action_remove">Remove</string>
 	<string name="preview_action_block">Block</string>
+	<string name="preview_action_pin">Pin</string>
+	<string name="preview_action_unpin">Unpin</string>
 	<string name="preview_action_open_in_browser">Browser</string>
+	<string name="cd_pinned">Pinned</string>
 	<string name="blocklist_title">Blocked wallpapers</string>
 	<string name="blocklist_settings_row">Blocked wallpapers</string>
 	<string name="blocklist_settings_subtitle">%d hidden from rotation</string>

--- a/app/src/test/java/xyz/attacktive/wallhavend/RotationDecisionsTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/RotationDecisionsTest.kt
@@ -1,0 +1,69 @@
+package xyz.attacktive.wallhavend
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import xyz.attacktive.wallhavend.domain.model.RotationMode
+import xyz.attacktive.wallhavend.domain.service.nextInCycle
+import xyz.attacktive.wallhavend.domain.service.shouldDownload
+
+class RotationDecisionsTest {
+	@Test
+	fun `offline never downloads, even when forced`() {
+		RotationMode.entries.forEach { mode ->
+			assertFalse(shouldDownload(mode, online = false, onWifi = false, forceDownload = false))
+			assertFalse(shouldDownload(mode, online = false, onWifi = true, forceDownload = true))
+		}
+	}
+
+	@Test
+	fun `fresh-any downloads whenever online`() {
+		assertTrue(shouldDownload(RotationMode.FRESH_ANY, online = true, onWifi = false, forceDownload = false))
+		assertTrue(shouldDownload(RotationMode.FRESH_ANY, online = true, onWifi = true, forceDownload = false))
+	}
+
+	@Test
+	fun `fresh-wifi downloads only on wifi`() {
+		assertTrue(shouldDownload(RotationMode.FRESH_WIFI, online = true, onWifi = true, forceDownload = false))
+		assertFalse(shouldDownload(RotationMode.FRESH_WIFI, online = true, onWifi = false, forceDownload = false))
+	}
+
+	@Test
+	fun `force overrides the wifi and pinned rules when online`() {
+		assertTrue(shouldDownload(RotationMode.FRESH_WIFI, online = true, onWifi = false, forceDownload = true))
+		assertTrue(shouldDownload(RotationMode.PINNED_ONLY, online = true, onWifi = false, forceDownload = true))
+	}
+
+	@Test
+	fun `pinned-only never auto-downloads`() {
+		assertFalse(shouldDownload(RotationMode.PINNED_ONLY, online = true, onWifi = true, forceDownload = false))
+	}
+
+	@Test
+	fun `nextInCycle returns null for an empty pool`() {
+		assertNull(nextInCycle(emptyList(), current = null))
+		assertNull(nextInCycle(emptyList(), current = "/a.jpg"))
+	}
+
+	@Test
+	fun `nextInCycle starts at the first entry when nothing is current`() {
+		assertEquals("/a.jpg", nextInCycle(listOf("/a.jpg", "/b.jpg"), current = null))
+	}
+
+	@Test
+	fun `nextInCycle advances to the following entry`() {
+		assertEquals("/b.jpg", nextInCycle(listOf("/a.jpg", "/b.jpg", "/c.jpg"), current = "/a.jpg"))
+	}
+
+	@Test
+	fun `nextInCycle wraps around past the last entry`() {
+		assertEquals("/a.jpg", nextInCycle(listOf("/a.jpg", "/b.jpg"), current = "/b.jpg"))
+	}
+
+	@Test
+	fun `nextInCycle starts over when the current path is not in the pool`() {
+		assertEquals("/a.jpg", nextInCycle(listOf("/a.jpg", "/b.jpg"), current = "/gone.jpg"))
+	}
+}

--- a/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.runTest
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -17,6 +18,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import xyz.attacktive.wallhavend.domain.model.AppSettings
+import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.query.Category
 import xyz.attacktive.wallhavend.domain.model.query.Purity
@@ -43,7 +45,7 @@ class SettingsRepositoryTest {
 		val settings = repository.settings.first()
 
 		assertEquals(60, settings.updateIntervalMinutes)
-		assertTrue(settings.wifiOnly)
+		assertEquals(RotationMode.FRESH_WIFI, settings.rotationMode)
 		assertEquals(10, settings.poolSize)
 		assertEquals(WallpaperTarget.HOME, settings.wallpaperTarget)
 		assertEquals(setOf(Category.GENERAL), settings.categories)
@@ -53,7 +55,7 @@ class SettingsRepositoryTest {
 	}
 
 	@Test
-	fun `wifiOnly is not read from legacy unmetered_only key`() = runTest {
+	fun `legacy unmetered_only key does not influence rotation mode`() = runTest {
 		val dataStore = PreferenceDataStoreFactory.create(
 			scope = backgroundScope,
 			produceFile = { tmpFolder.newFile("legacy_prefs.preferences_pb") }
@@ -65,7 +67,7 @@ class SettingsRepositoryTest {
 
 		val repository = SettingsRepository(dataStore, FakeAppLogger())
 
-		assertTrue(repository.settings.first().wifiOnly)
+		assertEquals(RotationMode.FRESH_WIFI, repository.settings.first().rotationMode)
 	}
 
 	@Test
@@ -77,7 +79,7 @@ class SettingsRepositoryTest {
 			purity = setOf(Purity.SFW, Purity.SKETCHY),
 			updateIntervalMinutes = 30,
 			wallpaperTarget = WallpaperTarget.HOME,
-			wifiOnly = false,
+			rotationMode = RotationMode.FRESH_ANY,
 			poolSize = 25,
 			apiKey = "secret",
 			autoStartOnBoot = true,
@@ -90,6 +92,79 @@ class SettingsRepositoryTest {
 		val loaded = repository.settings.first { it == modified }
 
 		assertEquals(modified, loaded)
+	}
+
+	@Test
+	fun `legacy wifiOnly false migrates to fresh-any rotation mode`() = runTest {
+		val dataStore = PreferenceDataStoreFactory.create(
+			scope = backgroundScope,
+			produceFile = { tmpFolder.newFile("migrate_any.preferences_pb") }
+		)
+
+		dataStore.edit { prefs -> prefs[booleanPreferencesKey("wifi_only")] = false }
+
+		val repository = SettingsRepository(dataStore, FakeAppLogger())
+
+		assertEquals(RotationMode.FRESH_ANY, repository.settings.first().rotationMode)
+	}
+
+	@Test
+	fun `legacy wifiOnly true migrates to fresh-wifi rotation mode`() = runTest {
+		val dataStore = PreferenceDataStoreFactory.create(
+			scope = backgroundScope,
+			produceFile = { tmpFolder.newFile("migrate_wifi.preferences_pb") }
+		)
+
+		dataStore.edit { prefs -> prefs[booleanPreferencesKey("wifi_only")] = true }
+
+		val repository = SettingsRepository(dataStore, FakeAppLogger())
+
+		assertEquals(RotationMode.FRESH_WIFI, repository.settings.first().rotationMode)
+	}
+
+	@Test
+	fun `explicit rotation mode wins over legacy wifiOnly`() = runTest {
+		val dataStore = PreferenceDataStoreFactory.create(
+			scope = backgroundScope,
+			produceFile = { tmpFolder.newFile("explicit_mode.preferences_pb") }
+		)
+
+		dataStore.edit { prefs ->
+			prefs[booleanPreferencesKey("wifi_only")] = false
+			prefs[stringPreferencesKey("rotation_mode")] = "PINNED_ONLY"
+		}
+
+		val repository = SettingsRepository(dataStore, FakeAppLogger())
+
+		assertEquals(RotationMode.PINNED_ONLY, repository.settings.first().rotationMode)
+	}
+
+	@Test
+	fun `rotation mode round-trips through save`() = runTest {
+		val repository = createRepository()
+		repository.save(AppSettings(searchQuery = "marker", rotationMode = RotationMode.PINNED_ONLY))
+
+		val loaded = repository.settings.first { it.searchQuery == "marker" }
+
+		assertEquals(RotationMode.PINNED_ONLY, loaded.rotationMode)
+	}
+
+	@Test
+	fun `pin and unpin round-trip and survive a full settings save`() = runTest {
+		val repository = createRepository()
+		assertTrue(repository.settings.first().pinnedIds.isEmpty())
+
+		repository.pin("abc123")
+		repository.pin("def456")
+		assertEquals(setOf("abc123", "def456"), repository.settings.first { it.pinnedIds.size == 2 }.pinnedIds)
+
+		repository.save(AppSettings(searchQuery = "marker"))
+
+		val afterSave = repository.settings.first { it.searchQuery == "marker" }
+		assertEquals(setOf("abc123", "def456"), afterSave.pinnedIds)
+
+		repository.unpin("abc123")
+		assertEquals(setOf("def456"), repository.settings.first { it.pinnedIds == setOf("def456") }.pinnedIds)
 	}
 
 	@Test

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallpaperFileManagerTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallpaperFileManagerTest.kt
@@ -99,4 +99,60 @@ class WallpaperFileManagerTest {
 
 		files.forEach { assertTrue("${it.name} should be deleted", !it.exists()) }
 	}
+
+	@Test
+	fun `trimToSize keeps a pinned file even when it is older than the cutoff`() {
+		val wallpapersDir = File(tmpFolder.root, "wallpapers").also { it.mkdirs() }
+		val files = (1..5).map { i ->
+			File(wallpapersDir, "w$i.jpg")
+				.also {
+					it.writeText("data")
+					it.setLastModified(System.currentTimeMillis() + i * 1000L)
+				}
+		}
+
+		// w1 is the oldest, so without a pin it would be the first evicted.
+		val kept = manager.trimToSize(2, setOf("w1"))
+
+		assertEquals(listOf("w5.jpg", "w4.jpg", "w1.jpg"), kept.map { it.name })
+		assertTrue(files[0].exists())
+		assertTrue(!files[1].exists())
+		assertTrue(!files[2].exists())
+		assertTrue(files[3].exists())
+		assertTrue(files[4].exists())
+	}
+
+	@Test
+	fun `trimToSize keeps pinned files when maxSize is 0`() {
+		val wallpapersDir = File(tmpFolder.root, "wallpapers").also { it.mkdirs() }
+		val rotating = File(wallpapersDir, "rot.jpg").also { it.writeText("data") }
+		val pinned = File(wallpapersDir, "pin.jpg").also { it.writeText("data") }
+
+		val kept = manager.trimToSize(0, setOf("pin"))
+
+		assertEquals(listOf("pin.jpg"), kept.map { it.name })
+		assertTrue(pinned.exists())
+		assertTrue(!rotating.exists())
+	}
+
+	@Test
+	fun `pinned files do not count toward maxSize`() {
+		val wallpapersDir = File(tmpFolder.root, "wallpapers").also { it.mkdirs() }
+		val files = (1..4).map { i ->
+			File(wallpapersDir, "w$i.jpg")
+				.also {
+					it.writeText("data")
+					it.setLastModified(System.currentTimeMillis() + i * 1000L)
+				}
+		}
+
+		// Pinning the oldest must not consume a rotating-buffer slot: the two newest non-pinned survive too.
+		val kept = manager.trimToSize(2, setOf("w1"))
+
+		assertEquals(3, kept.size)
+		assertTrue(files[0].exists())
+		assertTrue(!files[1].exists())
+		assertTrue(files[2].exists())
+		assertTrue(files[3].exists())
+	}
 }


### PR DESCRIPTION
Implements #66.

## Pin wallpapers
Pinned wallpapers are exempt from pool eviction (including at pool size 0) and don't count toward the rotating buffer's size. Pin/Unpin is a new action on the preview row (filled vs outlined pushpin, toggles in place), and pinned grid items show a pin badge. Removing or blocking a wallpaper also unpins it, so the pin count never goes stale. Storage mirrors the blocklist — a pinned_ids string-set in DataStore with atomic pin/unpin mutators.

## Rotation mode picker
A 3-way picker replaces the Wi-Fi-only toggle:
- Fresh — any network: download on any connection
- Fresh — Wi-Fi only: download on Wi-Fi, cycle the pool off-Wi-Fi (previous default)
- Pinned only: never auto-downloads, cycles only pinned wallpapers

"Pinned only" is disabled until at least one pin exists, with a runtime no-op safety net if pins later drop to zero. "Download now" stays live in every mode. Migration: legacy wifiOnly true → Fresh — Wi-Fi only, false → Fresh — any network; an explicit rotation mode always wins.

## Notes
- The download/cycle decision and the ring-walk are extracted as pure functions (shouldDownload, nextInCycle) and unit-tested; trimToSize pin-exemption and the settings migration / pin round-trips are covered too. 62 tests pass.
- All 7 locales were updated for the new schedule-tab strings; the Pin/Unpin labels intentionally fall back to English to match the already-untranslated preview action row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)