### PR TITLE
feature: raise minimum wallpaper pool size to 1

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
@@ -25,7 +25,7 @@ data class AppSettings(
 )
 
 val UPDATE_INTERVAL_OPTIONS = listOf(1, 5, 15, 30, 60, 180, 360, 1440)
-val POOL_SIZE_OPTIONS = listOf(0, 5, 10, 25, 50)
+val POOL_SIZE_OPTIONS = listOf(1, 5, 10, 25, 50)
 
 /**
  * Ratios with meaningful content on Wallhaven (verified by querying meta.total per ratio).

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -66,7 +66,7 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 				rotationMode = preferences[Keys.ROTATION_MODE]
 					?.let { runCatching { RotationMode.valueOf(it) }.getOrNull() }
 					?: migrateRotationMode(preferences[Keys.WIFI_ONLY]),
-				poolSize = preferences[Keys.POOL_SIZE] ?: 10,
+				poolSize = (preferences[Keys.POOL_SIZE] ?: 10).coerceAtLeast(1),
 				apiKey = preferences[Keys.API_KEY] ?: "",
 				autoStartOnBoot = preferences[Keys.AUTO_START_ON_BOOT] ?: true,
 				filterColor = preferences[Keys.FILTER_COLOR] ?: "",

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -592,11 +592,7 @@ private fun AdvancedTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 			RadioButton(selected = settings.poolSize == size, onClick = null)
 
 			Text(
-				text = if (size == 0) {
-					stringResource(R.string.settings_pool_size_zero)
-				} else {
-					"$size"
-				},
+				text = "$size",
 				modifier = Modifier.padding(start = 4.dp)
 			)
 		}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -37,7 +37,6 @@
 	<string name="settings_subtitle_auto_start">Kein Root erforderlich</string>
 	<string name="settings_label_pool_size">POOL-GRÖSSE</string>
 	<string name="settings_subtitle_pool_size">Hintergrundbilder, die auf dem Gerät behalten und in der Galerie angezeigt werden</string>
-	<string name="settings_pool_size_zero">0 — nur aktuelles, keine Galerie</string>
 	<string name="settings_label_api_key">API-KEY (OPTIONAL, FÜR NSFW ERFORDERLICH)</string>
 	<string name="settings_placeholder_api_key">Dein Wallhaven API-Key</string>
 	<string name="settings_powered_by">Unterstützt von wallhaven.cc</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -37,7 +37,6 @@
 	<string name="settings_subtitle_auto_start">No se requiere root</string>
 	<string name="settings_label_pool_size">TAMAÑO DEL DEPÓSITO DE FONDOS</string>
 	<string name="settings_subtitle_pool_size">Fondos de pantalla guardados en el dispositivo y mostrados en la galería</string>
-	<string name="settings_pool_size_zero">0 — solo actual, sin galería</string>
 	<string name="settings_label_api_key">CLAVE API (OPCIONAL, REQUERIDA PARA NSFW)</string>
 	<string name="settings_placeholder_api_key">Tu clave API de Wallhaven</string>
 	<string name="settings_powered_by">Desarrollado por wallhaven.cc</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -37,7 +37,6 @@
 	<string name="settings_subtitle_auto_start">Pas besoin de root</string>
 	<string name="settings_label_pool_size">TAILLE DE LA RÉSERVE</string>
 	<string name="settings_subtitle_pool_size">Fonds d\'écran gardés sur l\'appareil et affichés dans la galerie</string>
-	<string name="settings_pool_size_zero">0 — actuel uniquement, pas de galerie</string>
 	<string name="settings_label_api_key">CLÉ API (OPTIONNEL, REQUIS POUR NSFW)</string>
 	<string name="settings_placeholder_api_key">Votre clé API Wallhaven</string>
 	<string name="settings_powered_by">Propulsé par wallhaven.cc</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -37,7 +37,6 @@
 	<string name="settings_subtitle_auto_start">Root権限は不要です</string>
 	<string name="settings_label_pool_size">壁紙プールのサイズ</string>
 	<string name="settings_subtitle_pool_size">デバイスに保存され、ギャラリーに表示される壁紙の数</string>
-	<string name="settings_pool_size_zero">0 — 現在の壁紙のみ、ギャラリーなし</string>
 	<string name="settings_label_api_key">APIキー (任意、NSFWに必要)</string>
 	<string name="settings_placeholder_api_key">Wallhaven APIキー</string>
 	<string name="settings_powered_by">Powered by wallhaven.cc</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -37,7 +37,6 @@
 	<string name="settings_subtitle_auto_start">루트 권한이 필요하지 않습니다</string>
 	<string name="settings_label_pool_size">배경화면 풀 크기</string>
 	<string name="settings_subtitle_pool_size">기기에 보관되고 갤러리에 표시되는 배경화면 수</string>
-	<string name="settings_pool_size_zero">0 — 현재 배경화면만 사용, 갤러리 없음</string>
 	<string name="settings_label_api_key">API 키 (선택 사항, NSFW 필수)</string>
 	<string name="settings_placeholder_api_key">Wallhaven API 키</string>
 	<string name="settings_powered_by">Powered by wallhaven.cc</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -37,7 +37,6 @@
 	<string name="settings_subtitle_auto_start">Não requer root</string>
 	<string name="settings_label_pool_size">TAMANHO DA GALERIA</string>
 	<string name="settings_subtitle_pool_size">Papéis de parede mantidos no dispositivo e exibidos na galeria</string>
-	<string name="settings_pool_size_zero">0 — apenas atual, sem galeria</string>
 	<string name="settings_label_api_key">CHAVE API (OPCIONAL, NECESSÁRIA PARA NSFW)</string>
 	<string name="settings_placeholder_api_key">Sua chave API do Wallhaven</string>
 	<string name="settings_powered_by">Distribuído por wallhaven.cc</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -37,7 +37,6 @@
 	<string name="settings_subtitle_auto_start">无需 Root 权限</string>
 	<string name="settings_label_pool_size">壁纸缓存数量</string>
 	<string name="settings_subtitle_pool_size">在设备上保留并在图库中显示的壁纸数量</string>
-	<string name="settings_pool_size_zero">0 — 仅当前壁纸，不使用图库</string>
 	<string name="settings_label_api_key">API 密钥 (可选，访问 NSFW 内容必填)</string>
 	<string name="settings_placeholder_api_key">您的 Wallhaven API 密钥</string>
 	<string name="settings_powered_by">由 wallhaven.cc 提供支持</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,7 +53,6 @@
 	<string name="settings_subtitle_auto_start">No root required</string>
 	<string name="settings_label_pool_size">WALLPAPER POOL SIZE</string>
 	<string name="settings_subtitle_pool_size">Wallpapers kept on device and shown in gallery</string>
-	<string name="settings_pool_size_zero">0 — current only, no gallery</string>
 	<string name="settings_label_api_key">API KEY (OPTIONAL, REQUIRED FOR NSFW)</string>
 	<string name="settings_placeholder_api_key">Your Wallhaven API key</string>
 	<string name="settings_powered_by">Powered by wallhaven.cc</string>

--- a/app/src/test/java/xyz/attacktive/wallhavend/AppSettingsTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/AppSettingsTest.kt
@@ -1,0 +1,14 @@
+package xyz.attacktive.wallhavend
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import xyz.attacktive.wallhavend.domain.model.POOL_SIZE_OPTIONS
+
+class AppSettingsTest {
+	@Test
+	fun `pool size options never offer 0 so a fetched wallpaper always survives to be pinned`() {
+		assertFalse(0 in POOL_SIZE_OPTIONS)
+		assertEquals(1, POOL_SIZE_OPTIONS.min())
+	}
+}

--- a/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.runTest
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -68,6 +69,20 @@ class SettingsRepositoryTest {
 		val repository = SettingsRepository(dataStore, FakeAppLogger())
 
 		assertEquals(RotationMode.FRESH_WIFI, repository.settings.first().rotationMode)
+	}
+
+	@Test
+	fun `legacy pool size of 0 migrates to the new minimum of 1`() = runTest {
+		val dataStore = PreferenceDataStoreFactory.create(
+			scope = backgroundScope,
+			produceFile = { tmpFolder.newFile("migrate_pool.preferences_pb") }
+		)
+
+		dataStore.edit { prefs -> prefs[intPreferencesKey("pool_size")] = 0 }
+
+		val repository = SettingsRepository(dataStore, FakeAppLogger())
+
+		assertEquals(1, repository.settings.first().poolSize)
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Replaces the `0 — current only, no gallery` pool-size option with a floor of **1**. A freshly downloaded wallpaper now always survives `trimToSize` long enough to be pinned, instead of being deleted the instant after it's applied at `poolSize = 0`.

This falls out of the pinned-only rotation work in 1.8.0: in **Pinned only** mode, `Download now` stays live and fetches a fresh wallpaper. At the old `poolSize = 0`, `trimToSize(0, pinnedIds)` swept that candidate immediately, so there was nothing left on disk to pin. With a floor of 1, the single rotating slot becomes a free "audition" buffer — `Download now` fetches a candidate that persists until you pin it or the next download replaces it. No new state, the existing trim logic already does it.

## Changes

- `POOL_SIZE_OPTIONS`: `0 → 1` (now `1, 5, 10, 25, 50`)
- `SettingsRepository` read clamps with `coerceAtLeast(1)`, so a legacy stored `0` migrates to `1` (lazily; the next settings save persists it)
- Settings screen drops the `size == 0` special label
- Removes the now-unused `settings_pool_size_zero` string from the base locale and all 7 translations
- Tests: migration `0 → 1` round-trip, plus a guard so `0` can't be re-added to the options

## Trade-off

The only thing lost is the literal-zero-files / "no gallery" option. That promise was already half-broken in 1.8.0 — with pins present, `trimToSize(0, pinnedIds)` returns the pinned files, so the gallery already showed them. Smallest footprint is now one wallpaper file (the OS holds the current bitmap regardless). Upgrade is graceful: an empty cache stays empty on launch (no grid, no crash), Settings cleanly shows `1` selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)