### PR TITLE
refactor: deduplicate Category/Purity chip toggle logic in ContentTab

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -254,53 +254,22 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit, onN
 	Spacer(Modifier.height(16.dp))
 	SectionLabel(stringResource(R.string.settings_label_categories))
 
-	Row {
-		Category.entries.forEach { category ->
-			val isSelected = category in settings.categories
-			FilterChip(
-				selected = isSelected,
-				onClick = {
-					val newSet = if (isSelected && settings.categories.size > 1) {
-						settings.categories - category
-					} else if (!isSelected) {
-						settings.categories + category
-					} else {
-						settings.categories
-					}
-
-					onSave(settings.copy(categories = newSet))
-				},
-				label = { Text(stringResource(category.nameRes)) },
-				modifier = Modifier.padding(end = 8.dp)
-			)
-		}
-	}
+	MultiSelectChips(
+		entries = Category.entries,
+		selected = settings.categories,
+		nameRes = { it.nameRes },
+		onSelectionChange = { onSave(settings.copy(categories = it)) }
+	)
 
 	Spacer(Modifier.height(16.dp))
 	SectionLabel(stringResource(R.string.settings_label_content_rating))
 
-	Row {
-		Purity.entries.forEach { purity ->
-			val isSelected = purity in settings.purity
-
-			FilterChip(
-				selected = isSelected,
-				onClick = {
-					val newSet = if (isSelected && settings.purity.size > 1) {
-						settings.purity - purity
-					} else if (!isSelected) {
-						settings.purity + purity
-					} else {
-						settings.purity
-					}
-
-					onSave(settings.copy(purity = newSet))
-				},
-				label = { Text(stringResource(purity.nameRes)) },
-				modifier = Modifier.padding(end = 8.dp)
-			)
-		}
-	}
+	MultiSelectChips(
+		entries = Purity.entries,
+		selected = settings.purity,
+		nameRes = { it.nameRes },
+		onSelectionChange = { onSave(settings.copy(purity = it)) }
+	)
 
 	Spacer(Modifier.height(16.dp))
 	SectionLabel(stringResource(R.string.settings_label_filter_color))
@@ -609,6 +578,27 @@ private fun AdvancedTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 		keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
 		modifier = Modifier.fillMaxWidth()
 	)
+}
+
+@Composable
+private fun <T> MultiSelectChips(entries: List<T>, selected: Set<T>, nameRes: (T) -> Int, onSelectionChange: (Set<T>) -> Unit) {
+	Row {
+		entries.forEach { entry ->
+			FilterChip(
+				selected = entry in selected,
+				onClick = { onSelectionChange(selected.toggleKeepingOne(entry)) },
+				label = { Text(stringResource(nameRes(entry))) },
+				modifier = Modifier.padding(end = 8.dp)
+			)
+		}
+	}
+}
+
+/** Toggles [item] in the set, but never lets it empty out — the final remaining selection can't be removed. */
+internal fun <T> Set<T>.toggleKeepingOne(item: T) = when {
+	item !in this -> this + item
+	size > 1 -> this - item
+	else -> this
 }
 
 @Composable

--- a/app/src/test/java/xyz/attacktive/wallhavend/ToggleKeepingOneTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/ToggleKeepingOneTest.kt
@@ -1,0 +1,22 @@
+package xyz.attacktive.wallhavend
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import xyz.attacktive.wallhavend.ui.settings.toggleKeepingOne
+
+class ToggleKeepingOneTest {
+	@Test
+	fun `adds an item that is not selected yet`() {
+		assertEquals(setOf("a", "b"), setOf("a").toggleKeepingOne("b"))
+	}
+
+	@Test
+	fun `removes a selected item when others remain`() {
+		assertEquals(setOf("a"), setOf("a", "b").toggleKeepingOne("b"))
+	}
+
+	@Test
+	fun `keeps the last selected item instead of emptying the set`() {
+		assertEquals(setOf("a"), setOf("a").toggleKeepingOne("a"))
+	}
+}


### PR DESCRIPTION
## Summary

`Category` and `Purity` in `ContentTab` shared a copy-pasted "toggle this chip but keep at least one selected" block. Extracted a generic `MultiSelectChips<T>` composable plus a `toggleKeepingOne` extension on `Set<T>` that captures the never-empty invariant, and routed both sections through them. Pure refactor — no behavior change.

The extension is `internal` so a small unit test can pin the invariant: adds when absent, removes when others remain, and refuses to remove the last remaining selection.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)