### PR TITLE
bugfix: apply update-interval changes without waiting out the current delay

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -8,11 +8,17 @@ import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import android.app.Notification
 import android.app.NotificationManager
@@ -101,11 +107,8 @@ class WallpaperService: Service() {
 			settingsRepository.setAutoUpdateEnabled(true)
 			runCatching { performUpdate() }
 
-			while (true) {
-				val intervalMs = settingsRepository.settings.first().updateIntervalMinutes * 60_000L
-				delay(intervalMs.milliseconds)
-				runCatching { performUpdate() }
-			}
+			intervalTicks(settingsRepository.settings.map { it.updateIntervalMinutes })
+				.collect { runCatching { performUpdate() } }
 		}
 	}
 
@@ -405,3 +408,24 @@ class WallpaperService: Service() {
 		}
 	}
 }
+
+/**
+ * Emits a tick each time the active interval elapses, reflecting changes to [intervalsMinutes] live.
+ *
+ * A new interval cancels the in-flight wait and restarts it at the new length, so shortening the
+ * interval takes effect promptly instead of after the previous (possibly hours-long) delay finishes.
+ * [distinctUntilChanged] stops unrelated settings writes, which re-emit the same interval, from
+ * needlessly restarting the countdown.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+internal fun intervalTicks(intervalsMinutes: Flow<Int>): Flow<Unit> = intervalsMinutes
+	.distinctUntilChanged()
+	.flatMapLatest { intervalMinutes ->
+		flow {
+			while (true) {
+				delay((intervalMinutes * 60_000L).milliseconds)
+				emit(Unit)
+			}
+		}
+	}

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -2,7 +2,6 @@ package xyz.attacktive.wallhavend.ui.settings
 
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
-import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
@@ -63,7 +62,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -413,7 +411,6 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit, onN
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ScheduleTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
-	val context = LocalContext.current
 	var intervalExpanded by remember { mutableStateOf(false) }
 
 	SectionLabel(stringResource(R.string.settings_label_update_interval))
@@ -436,7 +433,6 @@ private fun ScheduleTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 					onClick = {
 						if (minutes != settings.updateIntervalMinutes) {
 							onSave(settings.copy(updateIntervalMinutes = minutes))
-							Toast.makeText(context, R.string.settings_toast_update_delay, Toast.LENGTH_SHORT).show()
 						}
 
 						intervalExpanded = false

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -92,7 +92,6 @@
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 Std.</string>
 	<string name="settings_unit_hr_plural">%d Std.</string>
-	<string name="settings_toast_update_delay">Wird beim nächsten Update wirksam</string>
 	<string name="settings_error_save_failed">Einstellungen konnten nicht gespeichert werden: %s</string>
 	<string name="home_msg_saved_to_pictures">Unter Pictures/Wallhavend gespeichert</string>
 	<string name="home_msg_save_failed">Speichern fehlgeschlagen: %s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -92,7 +92,6 @@
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 h</string>
 	<string name="settings_unit_hr_plural">%d h</string>
-	<string name="settings_toast_update_delay">Surte efecto en la próxima actualización</string>
 	<string name="settings_error_save_failed">Error al guardar los ajustes: %s</string>
 	<string name="home_msg_saved_to_pictures">Guardado en Pictures/Wallhavend</string>
 	<string name="home_msg_save_failed">Error al guardar: %s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -92,7 +92,6 @@
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 h</string>
 	<string name="settings_unit_hr_plural">%d h</string>
-	<string name="settings_toast_update_delay">Prendra effet à la prochaine mise à jour</string>
 	<string name="settings_error_save_failed">Échec de l\'enregistrement des paramètres : %s</string>
 	<string name="home_msg_saved_to_pictures">Enregistré dans Pictures/Wallhavend</string>
 	<string name="home_msg_save_failed">Échec de l\'enregistrement : %s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -92,7 +92,6 @@
 	<string name="settings_unit_min">%d分</string>
 	<string name="settings_unit_hr_single">1時間</string>
 	<string name="settings_unit_hr_plural">%d時間</string>
-	<string name="settings_toast_update_delay">次回の更新から適用されます</string>
 	<string name="settings_error_save_failed">設定の保存に失敗しました: %s</string>
 	<string name="home_msg_saved_to_pictures">Pictures/Wallhavendに保存しました</string>
 	<string name="home_msg_save_failed">保存に失敗しました: %s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -92,7 +92,6 @@
 	<string name="settings_unit_min">%d분</string>
 	<string name="settings_unit_hr_single">1시간</string>
 	<string name="settings_unit_hr_plural">%d시간</string>
-	<string name="settings_toast_update_delay">다음 업데이트부터 적용됩니다</string>
 	<string name="settings_error_save_failed">설정 저장 실패: %s</string>
 	<string name="home_msg_saved_to_pictures">Pictures/Wallhavend에 저장됨</string>
 	<string name="home_msg_save_failed">저장 실패: %s</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -92,7 +92,6 @@
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 h</string>
 	<string name="settings_unit_hr_plural">%d h</string>
-	<string name="settings_toast_update_delay">Entra em vigor na próxima atualização</string>
 	<string name="settings_error_save_failed">Falha ao salvar as configurações: %s</string>
 	<string name="home_msg_saved_to_pictures">Salvo em Pictures/Wallhavend</string>
 	<string name="home_msg_save_failed">Falha ao salvar: %s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -92,7 +92,6 @@
 	<string name="settings_unit_min">%d 分钟</string>
 	<string name="settings_unit_hr_single">1 小时</string>
 	<string name="settings_unit_hr_plural">%d 小时</string>
-	<string name="settings_toast_update_delay">将在下次更新时生效</string>
 	<string name="settings_error_save_failed">保存设置失败: %s</string>
 	<string name="home_msg_saved_to_pictures">已保存至 Pictures/Wallhavend</string>
 	<string name="home_msg_save_failed">保存失败: %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,7 +92,6 @@
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 hr</string>
 	<string name="settings_unit_hr_plural">%d hr</string>
-	<string name="settings_toast_update_delay">Takes effect on next update</string>
 	<string name="settings_error_save_failed">Failed to save settings: %s</string>
 	<string name="home_msg_saved_to_pictures">Saved to Pictures/Wallhavend</string>
 	<string name="home_msg_save_failed">Failed to save: %s</string>

--- a/app/src/test/java/xyz/attacktive/wallhavend/IntervalTicksTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/IntervalTicksTest.kt
@@ -1,0 +1,62 @@
+package xyz.attacktive.wallhavend
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import xyz.attacktive.wallhavend.domain.service.intervalTicks
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class IntervalTicksTest {
+	@Test
+	fun `shortening the interval cancels the in-flight wait and applies promptly`() = runTest {
+		val intervals = MutableStateFlow(360)
+		var ticks = 0
+
+		backgroundScope.launch { intervalTicks(intervals).collect { ticks++ } }
+		testScheduler.runCurrent()
+
+		// Five of the six hours pass: the wait has not elapsed yet.
+		testScheduler.advanceTimeBy(5 * 60 * 60_000L)
+		testScheduler.runCurrent()
+		assertEquals("no tick before the interval elapses", 0, ticks)
+
+		// Shorten to one minute while the six-hour wait is still in flight.
+		intervals.value = 1
+		testScheduler.runCurrent()
+
+		// One minute later — not the remaining hour of the old wait — a tick fires.
+		testScheduler.advanceTimeBy(60_000L)
+		testScheduler.runCurrent()
+		assertEquals("the shortened interval applies promptly", 1, ticks)
+
+		// And the loop keeps ticking at the new interval.
+		testScheduler.advanceTimeBy(60_000L)
+		testScheduler.runCurrent()
+		assertEquals("the loop keeps ticking at the new interval", 2, ticks)
+	}
+
+	@Test
+	fun `re-emitting the same interval does not restart the in-flight wait`() = runTest {
+		// An unrelated settings write re-emits the same interval nine minutes into a ten-minute wait.
+		val intervals = flow {
+			emit(10)
+			delay(9 * 60_000L)
+			emit(10)
+			delay(2 * 60_000L)
+		}
+
+		var ticks = 0
+
+		backgroundScope.launch { intervalTicks(intervals).collect { ticks++ } }
+		testScheduler.runCurrent()
+
+		testScheduler.advanceTimeBy(10 * 60_000L)
+		testScheduler.runCurrent()
+		assertEquals("a duplicate interval must not restart the wait", 1, ticks)
+	}
+}


### PR DESCRIPTION
Fixes the update timer ignoring interval changes until the in-flight delay finished — a change from 6h to 1m wouldn't apply until the running 6h wait elapsed.

The service now drives its update loop off the interval setting with flatMapLatest over distinctUntilChanged, so changing the interval cancels the in-flight wait and restarts it at the new length; a shortened interval applies promptly instead of only after the previous (up to 24h) delay. distinctUntilChanged keeps unrelated settings writes — which re-emit the same interval — from needlessly resetting the countdown.

[intervalTicks](https://github.com/Attacktive/Wallhavend-android/blob/69e8cc82b5a45dc93bd8a4afdf327e58c305bf23/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt#L422-L432)

Also removes the now-stale "Takes effect on next update" Toast and its 8 locale strings, since the change is no longer deferred.

Trade-off: changing the interval restarts the countdown from the moment of change rather than crediting already-elapsed time toward the new interval — matching the issue's suggested fix.

Closes #58
