### PR TITLE
feature: swipe horizontally in the preview to move between wallpapers

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
@@ -2,6 +2,7 @@ package xyz.attacktive.wallhavend.ui.preview
 
 import java.io.File
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import android.Manifest
 import android.content.Context
@@ -50,6 +51,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -144,6 +146,28 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 		currentId
 	}
 
+	val scope = rememberCoroutineScope()
+
+	/** Slides to a neighbor before evicting so the removed wallpaper animates away instead of popping. */
+	fun evictAndAdvance(evict: () -> Unit) {
+		if (state.poolPaths.size == 1) {
+			evict()
+			onNavigateBack()
+			return
+		}
+
+		val target = if (currentPage < state.poolPaths.lastIndex) {
+			currentPage + 1
+		} else {
+			currentPage - 1
+		}
+
+		scope.launch {
+			pagerState.animateScrollToPage(target)
+			evict()
+		}
+	}
+
 	Box(
 		modifier = Modifier
 			.fillMaxSize()
@@ -152,7 +176,7 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 				controlsVisible = !controlsVisible
 			}
 	) {
-		HorizontalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
+		HorizontalPager(state = pagerState, key = { state.poolPaths[it] }, modifier = Modifier.fillMaxSize()) { page ->
 			val pagePath = state.poolPaths.getOrNull(page) ?: return@HorizontalPager
 
 			AsyncImage(
@@ -241,27 +265,13 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 				PreviewAction(
 					icon = Icons.Default.Delete,
 					label = stringResource(R.string.preview_action_remove),
-					onClick = {
-						val isLastRemaining = state.poolPaths.size == 1
-						viewModel.deleteFromPool(currentPath)
-
-						if (isLastRemaining) {
-							onNavigateBack()
-						}
-					}
+					onClick = { evictAndAdvance { viewModel.deleteFromPool(currentPath) } }
 				)
 
 				PreviewAction(
 					icon = Icons.Default.Block,
 					label = stringResource(R.string.preview_action_block),
-					onClick = {
-						val isLastRemaining = state.poolPaths.size == 1
-						viewModel.blockFromPool(currentId, currentPath)
-
-						if (isLastRemaining) {
-							onNavigateBack()
-						}
-					}
+					onClick = { evictAndAdvance { viewModel.blockFromPool(currentId, currentPath) } }
 				)
 
 				PreviewAction(

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Block
@@ -70,19 +72,30 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 	val state by viewModel.serviceState.collectAsStateWithLifecycle()
 	val pinnedIds by viewModel.pinnedIds.collectAsStateWithLifecycle()
 	val context = LocalContext.current
-	val path = remember(state.poolPaths, id) {
-		state.poolPaths.firstOrNull { File(it).nameWithoutExtension == id }
-	}
 
 	/*
-	 * A null path means either the pool is still loading (empty on the first frame) or the
-	 * wallpaper was just removed. Only leave once the pool is loaded and the id is truly gone,
-	 * otherwise the screen would bounce straight back before the state arrives.
+	 * An empty pool means either it is still loading (empty on the first frame) or the last
+	 * wallpaper was just deleted. Show black and wait; a destructive action navigates back itself
+	 * when it empties the pool, so we never bounce out before the state arrives.
 	 */
-	if (path == null) {
-		if (state.poolPaths.isNotEmpty()) {
-			LaunchedEffect(Unit) { onNavigateBack() }
-		}
+	if (state.poolPaths.isEmpty()) {
+		Box(
+			modifier = Modifier
+				.fillMaxSize()
+				.background(Color.Black)
+		)
+
+		return
+	}
+
+	// Seed the pager at the tapped wallpaper once, when the pool is first available.
+	val initialPage = remember {
+		state.poolPaths.indexOfFirst { File(it).nameWithoutExtension == id }
+	}
+
+	// The tapped id is gone from a loaded pool (e.g. a stale deep-link); leave for the grid.
+	if (initialPage < 0) {
+		LaunchedEffect(Unit) { onNavigateBack() }
 
 		Box(
 			modifier = Modifier
@@ -93,9 +106,14 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 		return
 	}
 
+	val pagerState = rememberPagerState(initialPage = initialPage) { state.poolPaths.size }
+	val currentPage = pagerState.currentPage.coerceIn(0, state.poolPaths.lastIndex)
+	val currentPath = state.poolPaths[currentPage]
+	val currentId = File(currentPath).nameWithoutExtension
+
 	val writePermissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
 		if (granted) {
-			viewModel.saveToPictures(path)
+			viewModel.saveToPictures(currentPath)
 		}
 	}
 
@@ -107,10 +125,10 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 
 	var controlsVisible by remember { mutableStateOf(true) }
 
-	val resolution by produceState<String?>(initialValue = null, path) {
+	val resolution by produceState<String?>(initialValue = null, currentPath) {
 		value = withContext(Dispatchers.IO) {
 			val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-			BitmapFactory.decodeFile(path, options)
+			BitmapFactory.decodeFile(currentPath, options)
 
 			if (options.outWidth > 0 && options.outHeight > 0) {
 				"${options.outWidth}×${options.outHeight}"
@@ -121,9 +139,9 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 	}
 
 	val caption = if (resolution != null) {
-		"$id ($resolution)"
+		"$currentId ($resolution)"
 	} else {
-		id
+		currentId
 	}
 
 	Box(
@@ -134,12 +152,16 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 				controlsVisible = !controlsVisible
 			}
 	) {
-		AsyncImage(
-			model = File(path),
-			contentDescription = null,
-			contentScale = ContentScale.Fit,
-			modifier = Modifier.fillMaxSize()
-		)
+		HorizontalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
+			val pagePath = state.poolPaths.getOrNull(page) ?: return@HorizontalPager
+
+			AsyncImage(
+				model = File(pagePath),
+				contentDescription = null,
+				contentScale = ContentScale.Fit,
+				modifier = Modifier.fillMaxSize()
+			)
+		}
 
 		AnimatedVisibility(
 			visible = controlsVisible,
@@ -187,12 +209,12 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 					icon = Icons.Default.Wallpaper,
 					label = stringResource(R.string.preview_action_apply),
 					onClick = {
-						viewModel.applyFromPool(path)
+						viewModel.applyFromPool(currentPath)
 						goHome(context)
 					}
 				)
 
-				val isPinned = id in pinnedIds
+				val isPinned = currentId in pinnedIds
 
 				PreviewAction(
 					icon = if (isPinned) {
@@ -201,7 +223,7 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 						Icons.Outlined.PushPinOutlined
 					},
 					label = stringResource(if (isPinned) { R.string.preview_action_unpin } else { R.string.preview_action_pin }),
-					onClick = { viewModel.togglePin(id) }
+					onClick = { viewModel.togglePin(currentId) }
 				)
 
 				PreviewAction(
@@ -209,7 +231,7 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 					label = stringResource(R.string.preview_action_save),
 					onClick = {
 						if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-							viewModel.saveToPictures(path)
+							viewModel.saveToPictures(currentPath)
 						} else {
 							writePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
 						}
@@ -220,8 +242,12 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 					icon = Icons.Default.Delete,
 					label = stringResource(R.string.preview_action_remove),
 					onClick = {
-						viewModel.deleteFromPool(path)
-						onNavigateBack()
+						val isLastRemaining = state.poolPaths.size == 1
+						viewModel.deleteFromPool(currentPath)
+
+						if (isLastRemaining) {
+							onNavigateBack()
+						}
 					}
 				)
 
@@ -229,8 +255,12 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 					icon = Icons.Default.Block,
 					label = stringResource(R.string.preview_action_block),
 					onClick = {
-						viewModel.blockFromPool(id, path)
-						onNavigateBack()
+						val isLastRemaining = state.poolPaths.size == 1
+						viewModel.blockFromPool(currentId, currentPath)
+
+						if (isLastRemaining) {
+							onNavigateBack()
+						}
 					}
 				)
 
@@ -238,7 +268,7 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 					icon = Icons.Default.OpenInBrowser,
 					label = stringResource(R.string.preview_action_open_in_browser),
 					onClick = {
-						val intent = Intent(Intent.ACTION_VIEW, "https://wallhaven.cc/w/$id".toUri())
+						val intent = Intent(Intent.ACTION_VIEW, "https://wallhaven.cc/w/$currentId".toUri())
 						context.startActivity(intent)
 					}
 				)


### PR DESCRIPTION
Implements #84.

The full-screen preview is now a HorizontalPager over the pool, so browsing between wallpapers no longer requires backing out to the grid and tapping another tile.

- The tapped id seeds the initial page (no navigation change). Each page renders the same full-screen AsyncImage (ContentScale.Fit) as before.
- Overlays (top caption bar + bottom action row) read the currently-visible wallpaper via pagerState.currentPage, so caption, resolution, pin state, and every action operate on what is on screen.
- Tap-to-toggle controls visibility is unchanged. No wrap-around — swiping past the first/last wallpaper clamps.
- Destructive actions (delete / block) slide to a neighbor and then evict: forward to the next when one exists, otherwise back to the previous. Removing the only remaining wallpaper empties the pool and returns to the grid.

Pages are keyed by pool path, so the pager tracks wallpapers rather than slots. That makes the removal slide reconcile without a jump (the old page is dropped from behind the neighbor, which stays pinned), and as a side benefit it keeps the current wallpaper in view if a background update reorders the pool while the preview is open.

Contained to [PreviewScreen.kt](https://github.com/Attacktive/Wallhavend-android/blob/e1042ef2ffdeab6c3ab0295297f3432793e1587a/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt) — no ViewModel or navigation changes.

Minor edge: a delete/block now finishes after the ~300 ms slide, so hitting back within that window cancels the eviction along with the screen.