### PR TITLE
feature: warn on Home when pinned-only rotation has nothing pinned

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
@@ -56,6 +56,7 @@ import coil.compose.AsyncImage
 import xyz.attacktive.wallhavend.BuildConfig
 import xyz.attacktive.wallhavend.R
 import xyz.attacktive.wallhavend.domain.model.AppError
+import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.ServiceState
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -63,6 +64,7 @@ import xyz.attacktive.wallhavend.domain.model.ServiceState
 fun HomeScreen(onNavigateToSettings: () -> Unit, onNavigateToPreview: (String) -> Unit, viewModel: HomeViewModel = hiltViewModel()) {
 	val state by viewModel.serviceState.collectAsStateWithLifecycle()
 	val pinnedIds by viewModel.pinnedIds.collectAsStateWithLifecycle()
+	val rotationMode by viewModel.rotationMode.collectAsStateWithLifecycle()
 
 	Scaffold(
 		topBar = {
@@ -105,6 +107,13 @@ fun HomeScreen(onNavigateToSettings: () -> Unit, onNavigateToPreview: (String) -
 			if (!state.isOnline) {
 				Spacer(modifier = Modifier.height(8.dp))
 				OfflineBanner()
+			}
+
+			val pinnedRotationIdle = state.isRunning && rotationMode == RotationMode.PINNED_ONLY && pinnedIds.isEmpty()
+
+			if (pinnedRotationIdle) {
+				Spacer(modifier = Modifier.height(8.dp))
+				PinnedIdleBanner()
 			}
 
 			Spacer(modifier = Modifier.height(16.dp))
@@ -262,6 +271,17 @@ private fun OfflineBanner() {
 	Card(modifier = Modifier.fillMaxWidth()) {
 		Text(
 			text = stringResource(R.string.home_offline_banner),
+			modifier = Modifier.padding(12.dp),
+			style = MaterialTheme.typography.bodySmall
+		)
+	}
+}
+
+@Composable
+private fun PinnedIdleBanner() {
+	Card(modifier = Modifier.fillMaxWidth()) {
+		Text(
+			text = stringResource(R.string.home_pinned_idle_banner),
 			modifier = Modifier.padding(12.dp),
 			style = MaterialTheme.typography.bodySmall
 		)

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import xyz.attacktive.wallhavend.R
+import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.ServiceState
 import xyz.attacktive.wallhavend.domain.repository.ServiceStateRepository
 import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
@@ -39,6 +40,10 @@ class HomeViewModel @Inject constructor(
 	val pinnedIds = settingsRepository.settings
 		.map { it.pinnedIds }
 		.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
+
+	val rotationMode = settingsRepository.settings
+		.map { it.rotationMode }
+		.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), RotationMode.FRESH_WIFI)
 
 	private val _saveMessage = MutableSharedFlow<String>(extraBufferCapacity = 1)
 	val saveMessage = _saveMessage.asSharedFlow()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -9,6 +9,7 @@
 	<string name="home_action_download_now">Jetzt herunterladen</string>
 	<string name="home_recent_wallpapers">NEUESTE HINTERGRUNDBILDER</string>
 	<string name="home_offline_banner">Offline — Updates pausiert</string>
+	<string name="home_pinned_idle_banner">Die Rotation nur angehefteter Bilder ist inaktiv — hefte ein Hintergrundbild an oder wähle in den Einstellungen einen anderen Modus.</string>
 	<string name="settings_title">Einstellungen</string>
 	<string name="settings_tab_content">Inhalt</string>
 	<string name="settings_tab_schedule">Zeitplan</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -9,6 +9,7 @@
 	<string name="home_action_download_now">Descargar ahora</string>
 	<string name="home_recent_wallpapers">FONDOS DE PANTALLA RECIENTES</string>
 	<string name="home_offline_banner">Sin conexión — actualizaciones en pausa</string>
+	<string name="home_pinned_idle_banner">La rotación de solo fijados está inactiva — fija un fondo de pantalla o elige otro modo en Ajustes.</string>
 	<string name="settings_title">Ajustes</string>
 	<string name="settings_tab_content">Contenido</string>
 	<string name="settings_tab_schedule">Programación</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -9,6 +9,7 @@
 	<string name="home_action_download_now">Télécharger</string>
 	<string name="home_recent_wallpapers">FONDS D\'ÉCRAN RÉCENTS</string>
 	<string name="home_offline_banner">Hors ligne — mises à jour suspendues</string>
+	<string name="home_pinned_idle_banner">La rotation en mode épinglés uniquement est inactive — épinglez un fond d\'écran ou choisissez un autre mode dans les Paramètres.</string>
 	<string name="settings_title">Paramètres</string>
 	<string name="settings_tab_content">Contenu</string>
 	<string name="settings_tab_schedule">Plannification</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -9,6 +9,7 @@
 	<string name="home_action_download_now">今すぐダウンロード</string>
 	<string name="home_recent_wallpapers">最近の壁紙</string>
 	<string name="home_offline_banner">オフライン — 更新を一時停止しました</string>
+	<string name="home_pinned_idle_banner">ピン留めされた壁紙がありません — 壁紙をピン留めするか、設定で別のモードを選択してください</string>
 	<string name="settings_title">設定</string>
 	<string name="settings_tab_content">コンテンツ</string>
 	<string name="settings_tab_schedule">スケジュール</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -9,6 +9,7 @@
 	<string name="home_action_download_now">지금 다운로드</string>
 	<string name="home_recent_wallpapers">최근 배경화면</string>
 	<string name="home_offline_banner">오프라인 — 업데이트 일시 중지됨</string>
+	<string name="home_pinned_idle_banner">고정된 배경화면이 없습니다 — 배경화면을 고정하거나 설정에서 다른 모드를 선택하세요</string>
 	<string name="settings_title">설정</string>
 	<string name="settings_tab_content">콘텐츠</string>
 	<string name="settings_tab_schedule">일정</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -9,6 +9,7 @@
 	<string name="home_action_download_now">Baixar agora</string>
 	<string name="home_recent_wallpapers">PAPÉIS DE PAREDE RECENTES</string>
 	<string name="home_offline_banner">Offline — atualizações pausadas</string>
+	<string name="home_pinned_idle_banner">A rotação somente de fixados está inativa — fixe um papel de parede ou escolha outro modo em Configurações.</string>
 	<string name="settings_title">Configurações</string>
 	<string name="settings_tab_content">Conteúdo</string>
 	<string name="settings_tab_schedule">Agendamento</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -9,6 +9,7 @@
 	<string name="home_action_download_now">立即下载</string>
 	<string name="home_recent_wallpapers">最近壁纸</string>
 	<string name="home_offline_banner">离线 — 更新已暂停</string>
+	<string name="home_pinned_idle_banner">没有已置顶的壁纸 — 请置顶一张壁纸，或在设置中选择其他模式</string>
 	<string name="settings_title">设置</string>
 	<string name="settings_tab_content">内容</string>
 	<string name="settings_tab_schedule">计划</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
 	<string name="home_action_download_now">Download now</string>
 	<string name="home_recent_wallpapers">RECENT WALLPAPERS</string>
 	<string name="home_offline_banner">Offline — updates paused</string>
+	<string name="home_pinned_idle_banner">Pinned-only rotation is idle — pin a wallpaper or pick another mode in Settings.</string>
 	<string name="settings_title">Settings</string>
 	<string name="settings_tab_content">Content</string>
 	<string name="settings_tab_schedule">Schedule</string>


### PR DESCRIPTION
## Summary

Adds an informational Home banner that appears while auto-update is running in **Pinned only** mode but nothing is pinned. In that state the service falls into `cyclePinnedOnly` with an empty pool, so rotation silently stalls — no crash, no error, and the only hint lived back in Settings behind the greyed-out mode option. You can reach it by unpinning every wallpaper after selecting the mode; nothing resets the mode when the pin set empties.

The banner mirrors the existing `OfflineBanner` (plain neutral card, text only) and shows only when `isRunning && rotationMode == PINNED_ONLY && pinnedIds.isEmpty()`, so it never nags when auto-update is off. `rotationMode` is now exposed on `HomeViewModel` for the check. Copy is localized across all eight locales.

## Design notes

- **Informational over actionable/tinted** — parity with the Offline banner, and the fixes (the Settings gear, pinning from the grid) are already one tap away.
- **Banner only** — deliberately skipped the heavier options (auto-reverting the mode, or blocking the last unpin), which trade a passive quirk for an active surprise on a setting the user chose on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
