### PR TITLE
style: enlarge settings and home section labels

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
@@ -119,7 +119,7 @@ fun HomeScreen(onNavigateToSettings: () -> Unit, onNavigateToPreview: (String) -
 			Spacer(modifier = Modifier.height(16.dp))
 
 			if (state.poolPaths.isNotEmpty()) {
-				Text(stringResource(R.string.home_recent_wallpapers), style = MaterialTheme.typography.labelSmall)
+				Text(stringResource(R.string.home_recent_wallpapers), style = MaterialTheme.typography.labelMedium)
 				Spacer(modifier = Modifier.height(8.dp))
 
 				WallpaperGrid(

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -641,7 +641,7 @@ private fun PersistOnChange(value: String, upstream: String, onPersist: (String)
 private fun SectionLabel(text: String) {
 	Text(
 		text = text,
-		style = MaterialTheme.typography.labelSmall,
+		style = MaterialTheme.typography.labelLarge,
 		color = MaterialTheme.colorScheme.onSurfaceVariant,
 		modifier = Modifier.padding(bottom = 4.dp)
 	)


### PR DESCRIPTION
## Summary
- Bump settings section labels from `labelSmall` to `labelLarge` so uppercase headers are readable
- Slightly enlarge the home “recent wallpapers” label from `labelSmall` to `labelMedium`

## Test plan
- [x] Open Settings and confirm section headers (e.g. Categories, Update Interval) are clearly larger
- [x] Open Home with wallpapers in the pool and confirm the recent-wallpapers label looks balanced
- [x] Spot-check Content / Schedule / Advanced tabs for consistent label sizing


Made with [Cursor](https://cursor.com)