### PR TITLE
bugfix: stop splitting the search query on whitespace

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenRepository.kt
@@ -39,25 +39,36 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 		val toplistRange: String?
 	)
 
-	private fun AppSettings.toSearchKey(screenInfo: ScreenInfo) = SearchKey(
-		keywords = searchQuery.trim().split(Regex("[,;|\\s]+")).filter { it.isNotBlank() },
-		categories = categories.toBitString(),
-		purity = purity.toBitString(),
-		ratios = screenInfo.aspectRatio,
-		atleast = if (avoidBlurryWallpapers) {
-			"${screenInfo.width}x${screenInfo.height}"
-		} else {
-			null
-		},
-		colors = filterColor.ifBlank { null },
-		apiKey = apiKey.ifBlank { null },
-		sorting = sorting,
-		toplistRange = if (sorting == Sorting.TOPLIST) {
-			toplistRange.apiValue
-		} else {
-			null
-		}
-	)
+	private fun AppSettings.toSearchKey(screenInfo: ScreenInfo): SearchKey {
+		/*
+		 * Only explicit delimiters split the query, never whitespace.
+		 * Splitting on whitespace turned a phrase into unrelated searches that were then merged: "red car" became "red" (1690 portrait results) plus "car" (508) instead of the 76 that actually match both.
+		 * Trimming each keyword is what the delimiter class used to do for free, back when it also absorbed the spaces around a comma.
+		 */
+		val keywords = searchQuery.split(Regex("[,;|]+"))
+			.map { it.trim() }
+			.filter { it.isNotBlank() }
+
+		return SearchKey(
+			keywords = keywords,
+			categories = categories.toBitString(),
+			purity = purity.toBitString(),
+			ratios = screenInfo.aspectRatio,
+			atleast = if (avoidBlurryWallpapers) {
+				"${screenInfo.width}x${screenInfo.height}"
+			} else {
+				null
+			},
+			colors = filterColor.ifBlank { null },
+			apiKey = apiKey.ifBlank { null },
+			sorting = sorting,
+			toplistRange = if (sorting == Sorting.TOPLIST) {
+				toplistRange.apiValue
+			} else {
+				null
+			}
+		)
+	}
 
 	suspend fun next(settings: AppSettings, screenInfo: ScreenInfo): Result<Pair<Wallpaper, File>> = mutex.withLock {
 		val key = settings.toSearchKey(screenInfo)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -15,7 +15,7 @@
 	<string name="settings_tab_schedule">Zeitplan</string>
 	<string name="settings_tab_advanced">Erweitert</string>
 	<string name="settings_label_search_query">SUCHANFRAGE (OPTIONAL)</string>
-	<string name="settings_placeholder_search_query">z.B. landscape mountains</string>
+	<string name="settings_placeholder_search_query">z.B. milky way, mountains</string>
 	<string name="settings_label_categories">KATEGORIEN</string>
 	<string name="settings_label_content_rating">CONTENT-RATING</string>
 	<string name="settings_label_filter_color">FARBFILTER (OPTIONAL)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -15,7 +15,7 @@
 	<string name="settings_tab_schedule">Programación</string>
 	<string name="settings_tab_advanced">Avanzado</string>
 	<string name="settings_label_search_query">CONSULTA DE BÚSQUEDA (OPCIONAL)</string>
-	<string name="settings_placeholder_search_query">ej. landscape mountains</string>
+	<string name="settings_placeholder_search_query">ej. milky way, mountains</string>
 	<string name="settings_label_categories">CATEGORÍAS</string>
 	<string name="settings_label_content_rating">CLASIFICACIÓN DE CONTENIDO</string>
 	<string name="settings_label_filter_color">FILTRO DE COLOR (OPCIONAL)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -15,7 +15,7 @@
 	<string name="settings_tab_schedule">Plannification</string>
 	<string name="settings_tab_advanced">Avancé</string>
 	<string name="settings_label_search_query">RECHERCHE (OPTIONNEL)</string>
-	<string name="settings_placeholder_search_query">ex: landscape mountains</string>
+	<string name="settings_placeholder_search_query">ex: milky way, mountains</string>
 	<string name="settings_label_categories">CATÉGORIES</string>
 	<string name="settings_label_content_rating">CLASSEMENT DU CONTENU</string>
 	<string name="settings_label_filter_color">FILTRE COULEUR (OPTIONNEL)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -15,7 +15,7 @@
 	<string name="settings_tab_schedule">スケジュール</string>
 	<string name="settings_tab_advanced">詳細</string>
 	<string name="settings_label_search_query">検索クエリ (任意)</string>
-	<string name="settings_placeholder_search_query">例: landscape mountains</string>
+	<string name="settings_placeholder_search_query">例: milky way, mountains</string>
 	<string name="settings_label_categories">カテゴリ</string>
 	<string name="settings_label_content_rating">コンテンツ評価</string>
 	<string name="settings_label_filter_color">カラーフィルター (任意)</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -15,7 +15,7 @@
 	<string name="settings_tab_schedule">일정</string>
 	<string name="settings_tab_advanced">고급</string>
 	<string name="settings_label_search_query">검색어 (선택 사항)</string>
-	<string name="settings_placeholder_search_query">예: landscape mountains</string>
+	<string name="settings_placeholder_search_query">예: milky way, mountains</string>
 	<string name="settings_label_categories">카테고리</string>
 	<string name="settings_label_content_rating">콘텐츠 등급</string>
 	<string name="settings_label_filter_color">색상 필터 (선택 사항)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -15,7 +15,7 @@
 	<string name="settings_tab_schedule">Agendamento</string>
 	<string name="settings_tab_advanced">Avançado</string>
 	<string name="settings_label_search_query">TERMO DE BUSCA (OPCIONAL)</string>
-	<string name="settings_placeholder_search_query">ex: landscape mountains</string>
+	<string name="settings_placeholder_search_query">ex: milky way, mountains</string>
 	<string name="settings_label_categories">CATEGORIAS</string>
 	<string name="settings_label_content_rating">CLASSIFICAÇÃO DE CONTEÚDO</string>
 	<string name="settings_label_filter_color">FILTRO DE COR (OPCIONAL)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -15,7 +15,7 @@
 	<string name="settings_tab_schedule">计划</string>
 	<string name="settings_tab_advanced">高级</string>
 	<string name="settings_label_search_query">搜索内容 (可选)</string>
-	<string name="settings_placeholder_search_query">例如：landscape mountains</string>
+	<string name="settings_placeholder_search_query">例如：milky way, mountains</string>
 	<string name="settings_label_categories">分类</string>
 	<string name="settings_label_content_rating">内容分级</string>
 	<string name="settings_label_filter_color">颜色筛选（可选）</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
 	<string name="settings_tab_schedule">Schedule</string>
 	<string name="settings_tab_advanced">Advanced</string>
 	<string name="settings_label_search_query">SEARCH QUERY (OPTIONAL)</string>
-	<string name="settings_placeholder_search_query">e.g. landscape mountains</string>
+	<string name="settings_placeholder_search_query">e.g. milky way, mountains</string>
 	<string name="settings_label_categories">CATEGORIES</string>
 	<string name="settings_label_content_rating">CONTENT RATING</string>
 	<string name="settings_label_filter_color">COLOR FILTER (OPTIONAL)</string>

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallhavenRepositoryTest.kt
@@ -272,7 +272,7 @@ class WallhavenRepositoryTest {
 			Result.success(makeFile(firstArg<Wallpaper>().id))
 		}
 
-		val result = repository.next(AppSettings(searchQuery = "ocean mountains"), portraitScreen)
+		val result = repository.next(AppSettings(searchQuery = "ocean,mountains"), portraitScreen)
 		assertTrue(result.isSuccess)
 
 		coVerify(exactly = 1) {
@@ -312,7 +312,7 @@ class WallhavenRepositoryTest {
 
 		val ids = mutableListOf<String>()
 		repeat(5) {
-			val result = repository.next(AppSettings(searchQuery = "ocean mountains"), portraitScreen)
+			val result = repository.next(AppSettings(searchQuery = "ocean,mountains"), portraitScreen)
 			ids.add(result.getOrNull()!!.first.id)
 		}
 
@@ -369,6 +369,47 @@ class WallhavenRepositoryTest {
 			wallhavenApiService.search(
 				query = any(), categories = any(), purity = any(), ratios = any(), atleast = any(),
 				sorting = any(), seed = any(), topRange = any(), page = 2, colors = any(), apiKey = any()
+			)
+		}
+	}
+
+	@Test
+	fun `a multi-word query stays one phrase instead of splitting on whitespace`() = runTest {
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(1)
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		repository.next(AppSettings(searchQuery = "milky way"), portraitScreen)
+
+		coVerify(exactly = 1) {
+			wallhavenApiService.search(
+				query = "milky way", categories = any(), purity = any(), ratios = any(), atleast = any(),
+				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
+			)
+		}
+	}
+
+	@Test
+	fun `whitespace around an explicit delimiter is trimmed off each keyword`() = runTest {
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(1)
+		coEvery { fileManager.download(any()) } answers {
+			Result.success(makeFile(firstArg<Wallpaper>().id))
+		}
+
+		repository.next(AppSettings(searchQuery = "milky way, deep space"), portraitScreen)
+
+		coVerify(exactly = 1) {
+			wallhavenApiService.search(
+				query = "milky way", categories = any(), purity = any(), ratios = any(), atleast = any(),
+				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
+			)
+		}
+
+		coVerify(exactly = 1) {
+			wallhavenApiService.search(
+				query = "deep space", categories = any(), purity = any(), ratios = any(), atleast = any(),
+				sorting = any(), seed = any(), topRange = any(), page = any(), colors = any(), apiKey = any()
 			)
 		}
 	}


### PR DESCRIPTION
## Problem

The keyword split at `WallhavenRepository.kt:43` used `Regex("[,;|\\s]+")`, putting whitespace in the delimiter class alongside `,` `;` `|`. A multi-word query was therefore never searched as a phrase — it fanned out into one API request per word, and the results were merged into one pool.

Measured against the live Wallhaven API with `ratios=portrait`:

| query | results |
|---|---|
| `red car` as a phrase | **76** |
| `red` | 1690 |
| `car` | 508 |

Typing `red car` filled the rotation with ~2,000 wallpapers, the overwhelming majority containing no red car.

The damage scales with how common the individual words are. A distinctive phrase like `milky way` degraded only slightly — 36 as a phrase versus 39 for the merged `milky` ∪ `way`, just 3 spurious results — which is probably why this survived unnoticed.

## Fix

Whitespace comes out of the delimiter class. Explicit delimiters still split, so `cats, dogs` continues to fan out into two searches.

Each keyword is now trimmed individually. That part isn't cosmetic — `\s` in the delimiter class was silently absorbing the spaces around a comma, so removing it without a per-keyword trim would have sent `" mountains"` with a leading space.

`toSearchKey` picked up a block body and a local so the split reads on its own lines instead of as a long constructor argument.

## Tests

Two added:

- `a multi-word query stays one phrase instead of splitting on whitespace` — verifies exactly one call with `query = "milky way"`
- `whitespace around an explicit delimiter is trimmed off each keyword` — `"milky way, deep space"` must yield `"milky way"` and `"deep space"`

Both confirmed failing before the fix. The two existing multi-keyword tests moved from `"ocean mountains"` to `"ocean,mountains"`, since whitespace is no longer what makes them multi-keyword.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)