### PR TITLE
Keep auto-update off across reboot and app update

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
@@ -21,7 +21,8 @@ data class AppSettings(
 	val toplistRange: ToplistRange = ToplistRange.ONE_MONTH,
 	val avoidBlurryWallpapers: Boolean = false,
 	val blockedIds: Set<String> = emptySet(),
-	val pinnedIds: Set<String> = emptySet()
+	val pinnedIds: Set<String> = emptySet(),
+	val autoUpdateEnabled: Boolean = false
 )
 
 val UPDATE_INTERVAL_OPTIONS = listOf(1, 5, 15, 30, 60, 180, 360, 1440)

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -74,7 +74,8 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 				toplistRange = ToplistRange.fromApiValue(preferences[Keys.TOPLIST_RANGE] ?: "1M"),
 				avoidBlurryWallpapers = preferences[Keys.AVOID_BLURRY_WALLPAPERS] ?: false,
 				blockedIds = preferences[Keys.BLOCKED_IDS] ?: emptySet(),
-				pinnedIds = preferences[Keys.PINNED_IDS] ?: emptySet()
+				pinnedIds = preferences[Keys.PINNED_IDS] ?: emptySet(),
+				autoUpdateEnabled = preferences[Keys.AUTO_UPDATE_ENABLED] ?: false
 			)
 			.also { logger.debug(TAG, "read: ${it.redactedForLog()}") }
 		}
@@ -167,9 +168,8 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 	/**
 	 * Whether the user wants auto-update running. Persisted so the toggle survives process death:
 	 * the in-memory ServiceState.isRunning resets to false whenever the OS reclaims the process.
+	 * Isolated the same way as [block]/[pin]: read via [settings], written only through this mutator.
 	 */
-	suspend fun loadAutoUpdateEnabled() = dataStore.data.first()[Keys.AUTO_UPDATE_ENABLED] ?: false
-
 	suspend fun setAutoUpdateEnabled(enabled: Boolean) {
 		dataStore.edit { preferences -> preferences[Keys.AUTO_UPDATE_ENABLED] = enabled }
 	}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/BootReceiver.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/BootReceiver.kt
@@ -26,7 +26,7 @@ class BootReceiver: BroadcastReceiver() {
 		scope.launch {
 			try {
 				val settings = settingsRepository.settings.first()
-				if (settings.autoStartOnBoot) {
+				if (settings.autoStartOnBoot && settings.autoUpdateEnabled) {
 					WallpaperService.start(context)
 				}
 			} finally {

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -76,7 +77,7 @@ class HomeViewModel @Inject constructor(
 	 * this runs, so launching the foreground service is permitted.
 	 */
 	private suspend fun reconcileAutoUpdate() {
-		val enabled = settingsRepository.loadAutoUpdateEnabled()
+		val enabled = settingsRepository.settings.first().autoUpdateEnabled
 		val alreadyRunning = stateRepository.state.value.isRunning
 		if (enabled && !alreadyRunning) {
 			stateRepository.update { it.copy(isRunning = true) }

--- a/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
@@ -214,7 +214,7 @@ class SettingsRepositoryTest {
 	@Test
 	fun `auto-update enabled defaults to false`() = runTest {
 		val repository = createRepository()
-		assertFalse(repository.loadAutoUpdateEnabled())
+		assertFalse(repository.settings.first().autoUpdateEnabled)
 	}
 
 	@Test
@@ -236,6 +236,6 @@ class SettingsRepositoryTest {
 			FakeAppLogger()
 		)
 
-		assertTrue(secondProcess.loadAutoUpdateEnabled())
+		assertTrue(secondProcess.settings.first().autoUpdateEnabled)
 	}
 }


### PR DESCRIPTION
## Summary
- `BootReceiver` restarted the service on every boot/update based only on `autoStartOnBoot`, ignoring whether the user had explicitly stopped auto-update — `WallpaperService.startTimerLoop()` would then unconditionally re-mark auto-update as enabled, silently overriding an explicit Stop.
- Expose the persisted auto-update intent as an `AppSettings.autoUpdateEnabled` field (same isolation pattern as `blockedIds`/`pinnedIds`: read via `settings`, written only through `setAutoUpdateEnabled()`) and gate `BootReceiver`'s autostart on it alongside `autoStartOnBoot`, reusing the single settings read already there.
- Covers both `BOOT_COMPLETED` and `MY_PACKAGE_REPLACED` (app update), since `BootReceiver` handles both via the same code path.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests "*SettingsRepositoryTest*" --tests "*WallpaperServiceErrorTest*"` passes
- [x] `./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin` passes