### PR TITLE
refactor: qualify wallpapers by source behind a provider abstraction

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/data/api/dto/WallpaperDto.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/data/api/dto/WallpaperDto.kt
@@ -1,24 +1,18 @@
 package xyz.attacktive.wallhavend.data.api.dto
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import android.annotation.SuppressLint
 import xyz.attacktive.wallhavend.domain.model.Wallpaper
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 
 @SuppressLint("UnsafeOptInUsageError")
 @Serializable
-data class WallpaperDto(
-	val id: String,
-	val url: String,
-	val path: String,
-	val resolution: String,
-	@SerialName("file_type") val fileType: String
-)
+data class WallpaperDto(val id: String, val url: String, val path: String, val resolution: String)
 
 fun WallpaperDto.toDomain() = Wallpaper(
-	id = id,
+	identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, id),
 	pageUrl = url,
 	directUrl = path,
-	resolution = resolution,
-	mimeType = fileType
+	resolution = resolution
 )

--- a/app/src/main/java/xyz/attacktive/wallhavend/di/RepositoryModule.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/di/RepositoryModule.kt
@@ -11,7 +11,10 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
 import okhttp3.OkHttpClient
+import xyz.attacktive.wallhavend.domain.repository.WallhavenProvider
+import xyz.attacktive.wallhavend.domain.repository.WallpaperProvider
 import xyz.attacktive.wallhavend.domain.service.WallpaperFileManager
 
 private val Context.dataStore by preferencesDataStore(name = "wallhavend_settings")
@@ -30,4 +33,9 @@ object RepositoryModule {
 
 		return WallpaperFileManager(dir, okHttpClient)
 	}
+
+	/** Every source binds itself into this set, so WallpaperRepository blends whatever is registered without naming any of them. */
+	@Provides
+	@IntoSet
+	fun provideWallhavenProvider(wallhavenProvider: WallhavenProvider): WallpaperProvider = wallhavenProvider
 }

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/Wallpaper.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/Wallpaper.kt
@@ -1,9 +1,3 @@
 package xyz.attacktive.wallhavend.domain.model
 
-data class Wallpaper(val id: String, val pageUrl: String, val directUrl: String, val resolution: String, val mimeType: String) {
-	val fileExtension get() = when (mimeType) {
-		"image/jpeg" -> "jpg"
-		"image/png" -> "png"
-		else -> throw UnsupportedFormatException(mimeType)
-	}
-}
+data class Wallpaper(val identity: WallpaperIdentity, val pageUrl: String, val directUrl: String, val resolution: String)

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/WallpaperIdentity.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/WallpaperIdentity.kt
@@ -1,0 +1,54 @@
+package xyz.attacktive.wallhavend.domain.model
+
+/**
+ * A wallpaper, qualified by the source that served it.
+ * [qualified] is the single encoded form: it names the file on disk and keys the pinned and blocked sets, so ids from two sources can never collide.
+ */
+data class WallpaperIdentity(val source: WallpaperSource, val id: String) {
+	val qualified get() = "${source.key}$SEPARATOR$id"
+
+	/** The origin site's page for this wallpaper. */
+	val pageUrl get() = when (source) {
+		WallpaperSource.WALLHAVEN -> "https://wallhaven.cc/w/$id"
+	}
+
+	/** A remote thumbnail, for wallpapers with no local file left to show — a blocked one, say. */
+	val thumbnailUrl get() = when (source) {
+		WallpaperSource.WALLHAVEN -> "https://th.wallhaven.cc/lg/${id.take(2)}/$id.jpg"
+	}
+
+	/**
+	 * Every form this wallpaper can appear as in a persisted id set.
+	 * Installs predating source-qualified ids stored bare Wallhaven ids, so lookups have to accept that form and removals have to clear it.
+	 */
+	val persistedForms get() = when (source) {
+		WallpaperSource.WALLHAVEN -> setOf(qualified, id)
+	}
+
+	fun toFileName(extension: String) = "$qualified.$extension"
+
+	/** Whether [rawIds] — qualified or legacy bare — holds this wallpaper. */
+	fun matches(rawIds: Set<String>) = persistedForms.any { it in rawIds }
+
+	companion object {
+		private const val SEPARATOR = '_'
+
+		/**
+		 * Accepts the qualified form and the bare Wallhaven ids that older installs persisted.
+		 * That leniency *is* the migration: existing files, pins and blocks keep working with no DataStore migration and nothing renamed on disk, which would have invalidated the persisted current-wallpaper path.
+		 */
+		fun parse(raw: String): WallpaperIdentity {
+			val separatorIndex = raw.indexOf(SEPARATOR)
+			if (separatorIndex > 0) {
+				val source = WallpaperSource.fromKey(raw.take(separatorIndex))
+				val id = raw.substring(separatorIndex + 1)
+
+				if (source != null && id.isNotEmpty()) {
+					return WallpaperIdentity(source, id)
+				}
+			}
+
+			return WallpaperIdentity(WallpaperSource.WALLHAVEN, raw)
+		}
+	}
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/WallpaperSource.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/WallpaperSource.kt
@@ -1,0 +1,13 @@
+package xyz.attacktive.wallhavend.domain.model
+
+/**
+ * Where a wallpaper came from.
+ * [key] is the persisted discriminator, so renaming one orphans every id already stored on the device.
+ */
+enum class WallpaperSource(val key: String) {
+	WALLHAVEN("wallhaven");
+
+	companion object {
+		fun fromKey(key: String) = entries.firstOrNull { it.key == key }
+	}
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -14,6 +14,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.RotationMode
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.query.Category
 import xyz.attacktive.wallhavend.domain.model.query.Purity
@@ -113,29 +114,32 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 	 * The blocklist grows from the preview screen while the settings screen edits its own AppSettings
 	 * copy, so routing it through the whole-object save() would let one path clobber the other's writes.
 	 * These mutators touch only the blocked-ids key, and save() intentionally leaves that key alone.
+	 *
+	 * Ids go in qualified and come out by every form they could have been stored as, so a pin or block
+	 * made before wallpapers carried a source still gets cleared.
 	 */
-	suspend fun block(id: String) {
+	suspend fun block(identity: WallpaperIdentity) {
 		dataStore.edit { preferences ->
-			preferences[Keys.BLOCKED_IDS] = (preferences[Keys.BLOCKED_IDS] ?: emptySet()) + id
+			preferences[Keys.BLOCKED_IDS] = (preferences[Keys.BLOCKED_IDS] ?: emptySet()) + identity.qualified
 		}
 	}
 
-	suspend fun unblock(id: String) {
+	suspend fun unblock(identity: WallpaperIdentity) {
 		dataStore.edit { preferences ->
-			preferences[Keys.BLOCKED_IDS] = (preferences[Keys.BLOCKED_IDS] ?: emptySet()) - id
+			preferences[Keys.BLOCKED_IDS] = (preferences[Keys.BLOCKED_IDS] ?: emptySet()) - identity.persistedForms
 		}
 	}
 
 	/* Same isolation rationale as block/unblock: the pin set grows from the preview screen, so it gets its own key that save() leaves untouched. */
-	suspend fun pin(id: String) {
+	suspend fun pin(identity: WallpaperIdentity) {
 		dataStore.edit { preferences ->
-			preferences[Keys.PINNED_IDS] = (preferences[Keys.PINNED_IDS] ?: emptySet()) + id
+			preferences[Keys.PINNED_IDS] = (preferences[Keys.PINNED_IDS] ?: emptySet()) + identity.qualified
 		}
 	}
 
-	suspend fun unpin(id: String) {
+	suspend fun unpin(identity: WallpaperIdentity) {
 		dataStore.edit { preferences ->
-			preferences[Keys.PINNED_IDS] = (preferences[Keys.PINNED_IDS] ?: emptySet()) - id
+			preferences[Keys.PINNED_IDS] = (preferences[Keys.PINNED_IDS] ?: emptySet()) - identity.persistedForms
 		}
 	}
 

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenProvider.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenProvider.kt
@@ -1,6 +1,5 @@
 package xyz.attacktive.wallhavend.domain.repository
 
-import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.async
@@ -15,12 +14,14 @@ import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.NoResultsException
 import xyz.attacktive.wallhavend.domain.model.ScreenInfo
 import xyz.attacktive.wallhavend.domain.model.Wallpaper
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 import xyz.attacktive.wallhavend.domain.model.query.Sorting
 import xyz.attacktive.wallhavend.domain.model.query.toBitString
-import xyz.attacktive.wallhavend.domain.service.WallpaperFileManager
 
 @Singleton
-class WallhavenRepository @Inject constructor(private val wallhavenApiService: WallhavenApiService, private val fileManager: WallpaperFileManager) {
+class WallhavenProvider @Inject constructor(private val wallhavenApiService: WallhavenApiService): WallpaperProvider {
+	override val source = WallpaperSource.WALLHAVEN
+
 	private val mutex = Mutex()
 	private var cache = ArrayDeque<WallpaperDto>()
 	private var cacheKey: SearchKey? = null
@@ -70,7 +71,7 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 		)
 	}
 
-	suspend fun next(settings: AppSettings, screenInfo: ScreenInfo): Result<Pair<Wallpaper, File>> = mutex.withLock {
+	override suspend fun next(settings: AppSettings, screenInfo: ScreenInfo, blockedIds: Set<String>): Result<Wallpaper> = mutex.withLock {
 		val key = settings.toSearchKey(screenInfo)
 		if (key != cacheKey) {
 			cache.clear()
@@ -79,14 +80,11 @@ class WallhavenRepository @Inject constructor(private val wallhavenApiService: W
 			lastPage = 1
 		}
 
-		val selection = runCatching { selectNext(key, settings.blockedIds) }
+		val selection = runCatching { selectNext(key, blockedIds) }
 		val dto = selection.getOrElse { exception -> return@withLock Result.failure(exception) }
 			?: return@withLock Result.failure(NoResultsException())
 
-		val wallpaper = dto.toDomain()
-
-		fileManager.download(wallpaper)
-			.map { file -> Pair(wallpaper, file) }
+		Result.success(dto.toDomain())
 	}
 
 	/*

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallpaperProvider.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallpaperProvider.kt
@@ -1,0 +1,17 @@
+package xyz.attacktive.wallhavend.domain.repository
+
+import xyz.attacktive.wallhavend.domain.model.AppSettings
+import xyz.attacktive.wallhavend.domain.model.ScreenInfo
+import xyz.attacktive.wallhavend.domain.model.Wallpaper
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
+
+/**
+ * One source's search.
+ * A provider only picks a candidate; downloading it and blending sources is [WallpaperRepository]'s job, so a download that fails can fall back to another source.
+ */
+interface WallpaperProvider {
+	val source: WallpaperSource
+
+	/** [blockedIds] are bare ids belonging to this provider's own [source], already stripped of the qualifying prefix. */
+	suspend fun next(settings: AppSettings, screenInfo: ScreenInfo, blockedIds: Set<String>): Result<Wallpaper>
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallpaperRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallpaperRepository.kt
@@ -1,0 +1,53 @@
+package xyz.attacktive.wallhavend.domain.repository
+
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+import xyz.attacktive.wallhavend.domain.model.AppSettings
+import xyz.attacktive.wallhavend.domain.model.NoResultsException
+import xyz.attacktive.wallhavend.domain.model.ScreenInfo
+import xyz.attacktive.wallhavend.domain.model.Wallpaper
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
+import xyz.attacktive.wallhavend.domain.service.WallpaperFileManager
+
+/**
+ * Blends every registered source into one rotation.
+ * Sources are tried in random order so none of them dominates, and one that fails to search or to download hands over to the next instead of failing the whole update — only an all-sources-failed run surfaces an error.
+ */
+@Singleton
+class WallpaperRepository @Inject constructor(
+	private val providers: Set<@JvmSuppressWildcards WallpaperProvider>,
+	private val fileManager: WallpaperFileManager
+) {
+	suspend fun next(settings: AppSettings, screenInfo: ScreenInfo): Result<Pair<Wallpaper, File>> {
+		val failures = mutableListOf<Throwable>()
+
+		for (provider in providers.shuffled()) {
+			val blockedIds = blockedIdsFor(provider.source, settings.blockedIds)
+
+			val attempt = provider.next(settings, screenInfo, blockedIds)
+				.mapCatching { wallpaper -> wallpaper to fileManager.download(wallpaper).getOrThrow() }
+
+			if (attempt.isSuccess) {
+				return attempt
+			}
+
+			attempt.exceptionOrNull()
+				?.let { failures.add(it) }
+		}
+
+		return Result.failure(failures.mostInformative())
+	}
+
+	private fun blockedIdsFor(source: WallpaperSource, rawIds: Set<String>) = rawIds
+		.map { WallpaperIdentity.parse(it) }
+		.filter { it.source == source }
+		.map { it.id }
+		.toSet()
+}
+
+/** "No results" says the least about what went wrong, so a genuine search or download failure from any source wins the report. */
+private fun List<Throwable>.mostInformative() = firstOrNull { it !is NoResultsException }
+	?: firstOrNull()
+	?: NoResultsException()

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperFileManager.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperFileManager.kt
@@ -5,8 +5,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
 import xyz.attacktive.wallhavend.domain.model.UnsupportedFormatException
 import xyz.attacktive.wallhavend.domain.model.Wallpaper
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
 
 class WallpaperFileManager(private val wallpaperDir: File, private val okHttpClient: OkHttpClient) {
 	private val dir: File get() = wallpaperDir.also { it.mkdirs() }
@@ -22,12 +24,7 @@ class WallpaperFileManager(private val wallpaperDir: File, private val okHttpCli
 				.use { response ->
 					check(response.isSuccessful) { "HTTP ${response.code}" }
 
-					val contentType = response.body.contentType().toString()
-					if (!contentType.contains("image/jpeg") && !contentType.contains("image/png")) {
-						throw UnsupportedFormatException(contentType)
-					}
-
-					val file = File(dir, "${wallpaper.id}.${wallpaper.fileExtension}")
+					val file = File(dir, wallpaper.identity.toFileName(response.imageExtension()))
 
 					response.body
 						.byteStream()
@@ -43,7 +40,11 @@ class WallpaperFileManager(private val wallpaperDir: File, private val okHttpCli
 	fun listAll() = sortedFiles()
 
 	fun trimToSize(maxSize: Int, pinnedIds: Set<String> = emptySet()): List<File> {
-		val (pinned, rotating) = sortedFiles().partition { it.nameWithoutExtension in pinnedIds }
+		val (pinned, rotating) = sortedFiles()
+			.partition {
+				WallpaperIdentity.parse(it.nameWithoutExtension)
+					.matches(pinnedIds)
+			}
 
 		rotating.drop(maxSize)
 			.forEach { it.delete() }
@@ -55,4 +56,18 @@ class WallpaperFileManager(private val wallpaperDir: File, private val okHttpCli
 		dir.listFiles()
 			?.sortedByDescending { it.lastModified() }
 			?: emptyList()
+}
+
+/**
+ * The extension names what the server actually sent rather than what the search metadata claimed.
+ * Not every source reports a file type — Openverse leaves it null on most results — and the bytes are the reliable answer regardless.
+ */
+private fun Response.imageExtension(): String {
+	val contentType = body.contentType().toString()
+
+	return when {
+		contentType.contains("image/jpeg") -> "jpg"
+		contentType.contains("image/png") -> "png"
+		else -> throw UnsupportedFormatException(contentType)
+	}
 }

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -46,11 +46,12 @@ import xyz.attacktive.wallhavend.domain.model.NoResultsException
 import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.ScreenInfo
 import xyz.attacktive.wallhavend.domain.model.UnsupportedFormatException
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.closestAspectRatio
 import xyz.attacktive.wallhavend.domain.repository.ServiceStateRepository
 import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
-import xyz.attacktive.wallhavend.domain.repository.WallhavenRepository
+import xyz.attacktive.wallhavend.domain.repository.WallpaperRepository
 
 @AndroidEntryPoint
 class WallpaperService: Service() {
@@ -58,7 +59,7 @@ class WallpaperService: Service() {
 	lateinit var settingsRepository: SettingsRepository
 
 	@Inject
-	lateinit var wallhavenRepository: WallhavenRepository
+	lateinit var wallpaperRepository: WallpaperRepository
 
 	@Inject
 	lateinit var fileManager: WallpaperFileManager
@@ -131,7 +132,7 @@ class WallpaperService: Service() {
 	}
 
 	private suspend fun handleOnlineUpdate(settings: AppSettings) {
-		wallhavenRepository.next(settings, screenInfo())
+		wallpaperRepository.next(settings, screenInfo())
 			.fold(
 				onSuccess = { (_, file) -> onWallpaperFetched(file, settings) },
 				onFailure = { throwable -> onFetchError(throwable, settings) }
@@ -191,7 +192,10 @@ class WallpaperService: Service() {
 
 	private suspend fun cyclePinnedOnly(settings: AppSettings) {
 		val pool = fileManager.listAll()
-			.filter { it.nameWithoutExtension in settings.pinnedIds }
+			.filter {
+				WallpaperIdentity.parse(it.nameWithoutExtension)
+					.matches(settings.pinnedIds)
+			}
 			.reversed()
 			.map { it.absolutePath }
 

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/blocklist/BlocklistScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/blocklist/BlocklistScreen.kt
@@ -40,11 +40,12 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import xyz.attacktive.wallhavend.R
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BlocklistScreen(onNavigateBack: () -> Unit, viewModel: BlocklistViewModel = hiltViewModel()) {
-	val blockedIds by viewModel.blockedIds.collectAsStateWithLifecycle()
+	val blockedWallpapers by viewModel.blockedWallpapers.collectAsStateWithLifecycle()
 
 	Scaffold(
 		topBar = {
@@ -58,7 +59,7 @@ fun BlocklistScreen(onNavigateBack: () -> Unit, viewModel: BlocklistViewModel = 
 			)
 		}
 	) { padding ->
-		if (blockedIds.isEmpty()) {
+		if (blockedWallpapers.isEmpty()) {
 			Box(
 				contentAlignment = Alignment.Center,
 				modifier = Modifier
@@ -80,15 +81,15 @@ fun BlocklistScreen(onNavigateBack: () -> Unit, viewModel: BlocklistViewModel = 
 			.fillMaxSize()
 			.padding(padding)
 		) {
-			items(blockedIds, key = { it }) { id ->
-				BlockedRow(id = id, onUnblock = { viewModel.unblock(id) })
+			items(blockedWallpapers, key = { it.qualified }) { identity ->
+				BlockedRow(identity = identity, onUnblock = { viewModel.unblock(identity) })
 			}
 		}
 	}
 }
 
 @Composable
-private fun BlockedRow(id: String, onUnblock: () -> Unit) {
+private fun BlockedRow(identity: WallpaperIdentity, onUnblock: () -> Unit) {
 	val uriHandler = LocalUriHandler.current
 
 	Row(
@@ -97,7 +98,7 @@ private fun BlockedRow(id: String, onUnblock: () -> Unit) {
 			.fillMaxWidth()
 			.padding(horizontal = 16.dp, vertical = 8.dp)
 	) {
-		RevealableThumbnail(id = id)
+		RevealableThumbnail(identity = identity)
 
 		Column(
 			modifier = Modifier
@@ -105,11 +106,11 @@ private fun BlockedRow(id: String, onUnblock: () -> Unit) {
 				.padding(start = 16.dp)
 		) {
 			Text(
-				text = id,
+				text = identity.id,
 				style = MaterialTheme.typography.bodyLarge,
 				color = MaterialTheme.colorScheme.primary,
 				textDecoration = TextDecoration.Underline,
-				modifier = Modifier.clickable { uriHandler.openUri("https://wallhaven.cc/w/$id") }
+				modifier = Modifier.clickable { uriHandler.openUri(identity.pageUrl) }
 			)
 
 			Text(
@@ -130,8 +131,8 @@ private fun BlockedRow(id: String, onUnblock: () -> Unit) {
  * user chose to be rid of. The thumbnail loads from the network only after an explicit tap.
  */
 @Composable
-private fun RevealableThumbnail(id: String) {
-	var revealed by remember(id) { mutableStateOf(false) }
+private fun RevealableThumbnail(identity: WallpaperIdentity) {
+	var revealed by remember(identity) { mutableStateOf(false) }
 
 	Box(
 		contentAlignment = Alignment.Center,
@@ -143,7 +144,7 @@ private fun RevealableThumbnail(id: String) {
 	) {
 		if (revealed) {
 			AsyncImage(
-				model = "https://th.wallhaven.cc/lg/${id.take(2)}/$id.jpg",
+				model = identity.thumbnailUrl,
 				contentDescription = null,
 				contentScale = ContentScale.Crop,
 				modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/blocklist/BlocklistViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/blocklist/BlocklistViewModel.kt
@@ -8,17 +8,22 @@ import kotlinx.coroutines.launch
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
 import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
 
 @HiltViewModel
 class BlocklistViewModel @Inject constructor(private val settingsRepository: SettingsRepository): ViewModel() {
-	val blockedIds = settingsRepository.settings
-		.map { settings -> settings.blockedIds.sorted() }
+	val blockedWallpapers = settingsRepository.settings
+		.map { settings ->
+			settings.blockedIds
+				.map { WallpaperIdentity.parse(it) }
+				.sortedBy { it.id }
+		}
 		.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-	fun unblock(id: String) {
+	fun unblock(identity: WallpaperIdentity) {
 		viewModelScope.launch {
-			settingsRepository.unblock(id)
+			settingsRepository.unblock(identity)
 		}
 	}
 }

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeScreen.kt
@@ -58,6 +58,7 @@ import xyz.attacktive.wallhavend.R
 import xyz.attacktive.wallhavend.domain.model.AppError
 import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.ServiceState
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -197,7 +198,8 @@ private fun WallpaperGrid(paths: List<String>, currentPath: String?, pinnedIds: 
 	) {
 		items(paths) { path ->
 			val isCurrent = path == currentPath
-			val isPinned = File(path).nameWithoutExtension in pinnedIds
+			val isPinned = WallpaperIdentity.parse(File(path).nameWithoutExtension)
+				.matches(pinnedIds)
 
 			Box(
 				modifier = Modifier

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
@@ -23,6 +23,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import xyz.attacktive.wallhavend.R
 import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.ServiceState
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
 import xyz.attacktive.wallhavend.domain.repository.ServiceStateRepository
 import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
 import xyz.attacktive.wallhavend.domain.service.WallpaperFileManager
@@ -93,12 +94,12 @@ class HomeViewModel @Inject constructor(
 		WallpaperService.applyPath(context, path)
 	}
 
-	fun togglePin(id: String) {
+	fun togglePin(identity: WallpaperIdentity) {
 		viewModelScope.launch(Dispatchers.IO) {
-			if (id in pinnedIds.value) {
-				settingsRepository.unpin(id)
+			if (identity.matches(pinnedIds.value)) {
+				settingsRepository.unpin(identity)
 			} else {
-				settingsRepository.pin(id)
+				settingsRepository.pin(identity)
 			}
 		}
 	}
@@ -109,10 +110,10 @@ class HomeViewModel @Inject constructor(
 		}
 	}
 
-	fun blockFromPool(id: String, path: String) {
+	fun blockFromPool(identity: WallpaperIdentity, path: String) {
 		viewModelScope.launch(Dispatchers.IO) {
 			val currentBeforeBlock = stateRepository.state.value.currentWallpaperPath
-			settingsRepository.block(id)
+			settingsRepository.block(identity)
 			evictFromPool(path)
 
 			when (val replacement = blockReplacement(path, currentBeforeBlock, stateRepository.state.value.poolPaths)) {
@@ -125,7 +126,7 @@ class HomeViewModel @Inject constructor(
 
 	private suspend fun evictFromPool(path: String) {
 		val file = File(path)
-		settingsRepository.unpin(file.nameWithoutExtension)
+		settingsRepository.unpin(WallpaperIdentity.parse(file.nameWithoutExtension))
 		file.delete()
 
 		val state = stateRepository.state.value

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/preview/PreviewScreen.kt
@@ -67,6 +67,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import xyz.attacktive.wallhavend.R
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
 import xyz.attacktive.wallhavend.ui.home.HomeViewModel
 
 @Composable
@@ -92,7 +93,13 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 
 	// Seed the pager at the tapped wallpaper once, when the pool is first available.
 	val initialPage = remember {
-		state.poolPaths.indexOfFirst { File(it).nameWithoutExtension == id }
+		val identity = WallpaperIdentity.parse(id)
+
+		state.poolPaths.indexOfFirst { path ->
+			val pathIdentity = WallpaperIdentity.parse(File(path).nameWithoutExtension)
+
+			pathIdentity == identity
+		}
 	}
 
 	// The tapped id is gone from a loaded pool (e.g. a stale deep-link); leave for the grid.
@@ -111,7 +118,7 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 	val pagerState = rememberPagerState(initialPage = initialPage) { state.poolPaths.size }
 	val currentPage = pagerState.currentPage.coerceIn(0, state.poolPaths.lastIndex)
 	val currentPath = state.poolPaths[currentPage]
-	val currentId = File(currentPath).nameWithoutExtension
+	val currentIdentity = WallpaperIdentity.parse(File(currentPath).nameWithoutExtension)
 
 	val writePermissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
 		if (granted) {
@@ -141,9 +148,9 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 	}
 
 	val caption = if (resolution != null) {
-		"$currentId ($resolution)"
+		"${currentIdentity.id} ($resolution)"
 	} else {
-		currentId
+		currentIdentity.id
 	}
 
 	val scope = rememberCoroutineScope()
@@ -238,7 +245,7 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 					}
 				)
 
-				val isPinned = currentId in pinnedIds
+				val isPinned = currentIdentity.matches(pinnedIds)
 
 				PreviewAction(
 					icon = if (isPinned) {
@@ -247,7 +254,7 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 						Icons.Outlined.PushPinOutlined
 					},
 					label = stringResource(if (isPinned) { R.string.preview_action_unpin } else { R.string.preview_action_pin }),
-					onClick = { viewModel.togglePin(currentId) }
+					onClick = { viewModel.togglePin(currentIdentity) }
 				)
 
 				PreviewAction(
@@ -271,14 +278,14 @@ fun PreviewScreen(id: String, onNavigateBack: () -> Unit, viewModel: HomeViewMod
 				PreviewAction(
 					icon = Icons.Default.Block,
 					label = stringResource(R.string.preview_action_block),
-					onClick = { evictAndAdvance { viewModel.blockFromPool(currentId, currentPath) } }
+					onClick = { evictAndAdvance { viewModel.blockFromPool(currentIdentity, currentPath) } }
 				)
 
 				PreviewAction(
 					icon = Icons.Default.OpenInBrowser,
 					label = stringResource(R.string.preview_action_open_in_browser),
 					onClick = {
-						val intent = Intent(Intent.ACTION_VIEW, "https://wallhaven.cc/w/$currentId".toUri())
+						val intent = Intent(Intent.ACTION_VIEW, currentIdentity.pageUrl.toUri())
 						context.startActivity(intent)
 					}
 				)

--- a/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
@@ -12,6 +12,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -20,6 +21,8 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.RotationMode
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.query.Category
 import xyz.attacktive.wallhavend.domain.model.query.Purity
@@ -30,6 +33,8 @@ import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
 class SettingsRepositoryTest {
 	@get:Rule
 	val tmpFolder = TemporaryFolder()
+
+	private fun wallhaven(id: String) = WallpaperIdentity(WallpaperSource.WALLHAVEN, id)
 
 	private fun TestScope.createRepository(): SettingsRepository {
 		val dataStore = PreferenceDataStoreFactory.create(
@@ -169,17 +174,17 @@ class SettingsRepositoryTest {
 		val repository = createRepository()
 		assertTrue(repository.settings.first().pinnedIds.isEmpty())
 
-		repository.pin("abc123")
-		repository.pin("def456")
-		assertEquals(setOf("abc123", "def456"), repository.settings.first { it.pinnedIds.size == 2 }.pinnedIds)
+		repository.pin(wallhaven("abc123"))
+		repository.pin(wallhaven("def456"))
+		assertEquals(setOf("wallhaven_abc123", "wallhaven_def456"), repository.settings.first { it.pinnedIds.size == 2 }.pinnedIds)
 
 		repository.save(AppSettings(searchQuery = "marker"))
 
 		val afterSave = repository.settings.first { it.searchQuery == "marker" }
-		assertEquals(setOf("abc123", "def456"), afterSave.pinnedIds)
+		assertEquals(setOf("wallhaven_abc123", "wallhaven_def456"), afterSave.pinnedIds)
 
-		repository.unpin("abc123")
-		assertEquals(setOf("def456"), repository.settings.first { it.pinnedIds == setOf("def456") }.pinnedIds)
+		repository.unpin(wallhaven("abc123"))
+		assertEquals(setOf("wallhaven_def456"), repository.settings.first { it.pinnedIds == setOf("wallhaven_def456") }.pinnedIds)
 	}
 
 	@Test
@@ -187,17 +192,47 @@ class SettingsRepositoryTest {
 		val repository = createRepository()
 		assertTrue(repository.settings.first().blockedIds.isEmpty())
 
-		repository.block("abc123")
-		repository.block("def456")
-		assertEquals(setOf("abc123", "def456"), repository.settings.first { it.blockedIds.size == 2 }.blockedIds)
+		repository.block(wallhaven("abc123"))
+		repository.block(wallhaven("def456"))
+		assertEquals(setOf("wallhaven_abc123", "wallhaven_def456"), repository.settings.first { it.blockedIds.size == 2 }.blockedIds)
 
 		repository.save(AppSettings(searchQuery = "marker"))
 
 		val afterSave = repository.settings.first { it.searchQuery == "marker" }
-		assertEquals(setOf("abc123", "def456"), afterSave.blockedIds)
+		assertEquals(setOf("wallhaven_abc123", "wallhaven_def456"), afterSave.blockedIds)
 
-		repository.unblock("abc123")
-		assertEquals(setOf("def456"), repository.settings.first { it.blockedIds == setOf("def456") }.blockedIds)
+		repository.unblock(wallhaven("abc123"))
+		assertEquals(setOf("wallhaven_def456"), repository.settings.first { it.blockedIds == setOf("wallhaven_def456") }.blockedIds)
+	}
+
+	@Test
+	fun `unpinning clears a pin stored before wallpapers carried a source`() = runTest {
+		val dataStore = PreferenceDataStoreFactory.create(
+			scope = backgroundScope,
+			produceFile = { tmpFolder.newFile("legacy_pins.preferences_pb") }
+		)
+
+		dataStore.edit { prefs -> prefs[stringSetPreferencesKey("pinned_ids")] = setOf("abc123") }
+
+		val repository = SettingsRepository(dataStore, FakeAppLogger())
+		repository.unpin(wallhaven("abc123"))
+
+		assertTrue(repository.settings.first { it.pinnedIds.isEmpty() }.pinnedIds.isEmpty())
+	}
+
+	@Test
+	fun `unblocking clears a block stored before wallpapers carried a source`() = runTest {
+		val dataStore = PreferenceDataStoreFactory.create(
+			scope = backgroundScope,
+			produceFile = { tmpFolder.newFile("legacy_blocks.preferences_pb") }
+		)
+
+		dataStore.edit { prefs -> prefs[stringSetPreferencesKey("blocked_ids")] = setOf("abc123") }
+
+		val repository = SettingsRepository(dataStore, FakeAppLogger())
+		repository.unblock(wallhaven("abc123"))
+
+		assertTrue(repository.settings.first { it.blockedIds.isEmpty() }.blockedIds.isEmpty())
 	}
 
 	@Test

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallhavenProviderTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallhavenProviderTest.kt
@@ -1,6 +1,5 @@
 package xyz.attacktive.wallhavend
 
-import java.io.File
 import kotlinx.coroutines.test.runTest
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -16,21 +15,19 @@ import xyz.attacktive.wallhavend.data.api.dto.WallpaperDto
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.NoResultsException
 import xyz.attacktive.wallhavend.domain.model.ScreenInfo
-import xyz.attacktive.wallhavend.domain.model.Wallpaper
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 import xyz.attacktive.wallhavend.domain.model.query.Sorting
 import xyz.attacktive.wallhavend.domain.model.query.ToplistRange
-import xyz.attacktive.wallhavend.domain.repository.WallhavenRepository
-import xyz.attacktive.wallhavend.domain.service.WallpaperFileManager
+import xyz.attacktive.wallhavend.domain.repository.WallhavenProvider
 
-class WallhavenRepositoryTest {
+class WallhavenProviderTest {
 	private val wallhavenApiService = mockk<WallhavenApiService>()
-	private val fileManager = mockk<WallpaperFileManager>()
-	private lateinit var repository: WallhavenRepository
+	private lateinit var provider: WallhavenProvider
 
 	private val portraitScreen = ScreenInfo("9x16", 1080, 2400)
 	private val landscapeScreen = ScreenInfo("16x9", 2400, 1080)
 
-	private fun makeDto(id: String) = WallpaperDto(id, "https://wallhaven.cc/$id", "https://cdn/w/$id.jpg", "1920x1080", "image/jpeg")
+	private fun makeDto(id: String) = WallpaperDto(id, "https://wallhaven.cc/$id", "https://cdn/w/$id.jpg", "1920x1080")
 
 	private fun makePage(count: Int, currentPage: Int = 1, lastPage: Int = 1, idPrefix: String = "w"): SearchResponseDto {
 		val data = (1..count)
@@ -47,36 +44,38 @@ class WallhavenRepositoryTest {
 		return SearchResponseDto(data, MetaDto(currentPage, lastPage, 24, count))
 	}
 
-	private fun makeFile(id: String) = File("/tmp/$id.jpg")
-
 	@Before
 	fun setUp() {
-		repository = WallhavenRepository(wallhavenApiService, fileManager)
+		provider = WallhavenProvider(wallhavenApiService)
 	}
 
 	@Test
 	fun `next fetches from API and returns first result`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		val result = repository.next(AppSettings(), portraitScreen)
+		val result = provider.next(AppSettings(), portraitScreen, emptySet())
 		assertTrue(result.isSuccess)
-		assertEquals("w1", result.getOrNull()?.first?.id)
+		assertEquals("w1", result.getOrNull()?.identity?.id)
 
 		coVerify(exactly = 1) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
 
 	@Test
+	fun `next qualifies the returned wallpaper with its source`() = runTest {
+		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(1)
+
+		val identity = provider.next(AppSettings(), portraitScreen, emptySet()).getOrNull()?.identity
+
+		assertEquals(WallpaperSource.WALLHAVEN, identity?.source)
+		assertEquals("wallhaven_w1", identity?.qualified)
+	}
+
+	@Test
 	fun `next reuses cache on second call`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		repository.next(AppSettings(), portraitScreen)
-		repository.next(AppSettings(), portraitScreen)
+		provider.next(AppSettings(), portraitScreen, emptySet())
+		provider.next(AppSettings(), portraitScreen, emptySet())
 
 		coVerify(exactly = 1) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -84,12 +83,9 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `cache invalidates when query changes`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		repository.next(AppSettings(searchQuery = "mountains"), portraitScreen)
-		repository.next(AppSettings(searchQuery = "ocean"), portraitScreen)
+		provider.next(AppSettings(searchQuery = "mountains"), portraitScreen, emptySet())
+		provider.next(AppSettings(searchQuery = "ocean"), portraitScreen, emptySet())
 
 		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -97,12 +93,9 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `cache invalidates when filterColor changes`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		repository.next(AppSettings(filterColor = "cc0000"), portraitScreen)
-		repository.next(AppSettings(filterColor = "0066cc"), portraitScreen)
+		provider.next(AppSettings(filterColor = "cc0000"), portraitScreen, emptySet())
+		provider.next(AppSettings(filterColor = "0066cc"), portraitScreen, emptySet())
 
 		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -110,12 +103,9 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `cache invalidates when sorting changes`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		repository.next(AppSettings(sorting = Sorting.RANDOM), portraitScreen)
-		repository.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen)
+		provider.next(AppSettings(sorting = Sorting.RANDOM), portraitScreen, emptySet())
+		provider.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen, emptySet())
 
 		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -123,12 +113,9 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `cache invalidates when toplistRange changes`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		repository.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_MONTH), portraitScreen)
-		repository.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_YEAR), portraitScreen)
+		provider.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_MONTH), portraitScreen, emptySet())
+		provider.next(AppSettings(sorting = Sorting.TOPLIST, toplistRange = ToplistRange.ONE_YEAR), portraitScreen, emptySet())
 
 		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -136,12 +123,9 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `cache invalidates when aspect ratio changes`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		repository.next(AppSettings(), portraitScreen)
-		repository.next(AppSettings(), landscapeScreen)
+		provider.next(AppSettings(), portraitScreen, emptySet())
+		provider.next(AppSettings(), landscapeScreen, emptySet())
 
 		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -149,12 +133,9 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `cache invalidates when avoidBlurryWallpapers changes`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		repository.next(AppSettings(avoidBlurryWallpapers = false), portraitScreen)
-		repository.next(AppSettings(avoidBlurryWallpapers = true), portraitScreen)
+		provider.next(AppSettings(avoidBlurryWallpapers = false), portraitScreen, emptySet())
+		provider.next(AppSettings(avoidBlurryWallpapers = true), portraitScreen, emptySet())
 
 		coVerify(exactly = 2) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
 	}
@@ -162,11 +143,8 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `atleast is sent as screen resolution when avoidBlurryWallpapers is on`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		repository.next(AppSettings(avoidBlurryWallpapers = true), portraitScreen)
+		provider.next(AppSettings(avoidBlurryWallpapers = true), portraitScreen, emptySet())
 
 		coVerify(exactly = 1) {
 			wallhavenApiService.search(
@@ -179,11 +157,8 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `atleast is omitted when avoidBlurryWallpapers is off`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		repository.next(AppSettings(avoidBlurryWallpapers = false), portraitScreen)
+		provider.next(AppSettings(avoidBlurryWallpapers = false), portraitScreen, emptySet())
 
 		coVerify(exactly = 1) {
 			wallhavenApiService.search(
@@ -197,7 +172,7 @@ class WallhavenRepositoryTest {
 	fun `returns NoResultsException when API returns empty list`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(0)
 
-		val result = repository.next(AppSettings(), portraitScreen)
+		val result = provider.next(AppSettings(), portraitScreen, emptySet())
 		assertTrue(result.isFailure)
 		assertTrue(result.exceptionOrNull() is NoResultsException)
 	}
@@ -220,21 +195,17 @@ class WallhavenRepositoryTest {
 			)
 		} returns makePage(count = 1, currentPage = 2, lastPage = 2)
 
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
-
 		// First call - should request page 1
-		val res1 = repository.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen)
-		assertEquals("w-1-1", res1.getOrNull()?.first?.id)
+		val res1 = provider.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen, emptySet())
+		assertEquals("w-1-1", res1.getOrNull()?.identity?.id)
 
 		// Second call - cache is empty, should request page 2
-		val res2 = repository.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen)
-		assertEquals("w-2-1", res2.getOrNull()?.first?.id)
+		val res2 = provider.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen, emptySet())
+		assertEquals("w-2-1", res2.getOrNull()?.identity?.id)
 
 		// Third call - cache is empty, currentPage (3) > lastPage (2), should wrap back and request page 1
-		val res3 = repository.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen)
-		assertEquals("w-1-1", res3.getOrNull()?.first?.id)
+		val res3 = provider.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen, emptySet())
+		assertEquals("w-1-1", res3.getOrNull()?.identity?.id)
 
 		// Verify page 1 was requested twice, page 2 was requested once
 		coVerify(exactly = 2) {
@@ -268,11 +239,7 @@ class WallhavenRepositoryTest {
 			)
 		} returns makePage(2, idPrefix = "mountains")
 
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
-
-		val result = repository.next(AppSettings(searchQuery = "ocean,mountains"), portraitScreen)
+		val result = provider.next(AppSettings(searchQuery = "ocean,mountains"), portraitScreen, emptySet())
 		assertTrue(result.isSuccess)
 
 		coVerify(exactly = 1) {
@@ -306,14 +273,10 @@ class WallhavenRepositoryTest {
 			)
 		} returns makePage(2, idPrefix = "mountains")
 
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
-
 		val ids = mutableListOf<String>()
 		repeat(5) {
-			val result = repository.next(AppSettings(searchQuery = "ocean,mountains"), portraitScreen)
-			ids.add(result.getOrNull()!!.first.id)
+			val result = provider.next(AppSettings(searchQuery = "ocean,mountains"), portraitScreen, emptySet())
+			ids.add(result.getOrNull()!!.identity.id)
 		}
 
 		assertEquals(5, ids.size)
@@ -325,19 +288,16 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `next skips blocked ids`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(5)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		val result = repository.next(AppSettings(blockedIds = setOf("w1", "w2")), portraitScreen)
-		assertEquals("w3", result.getOrNull()?.first?.id)
+		val result = provider.next(AppSettings(), portraitScreen, setOf("w1", "w2"))
+		assertEquals("w3", result.getOrNull()?.identity?.id)
 	}
 
 	@Test
 	fun `next returns NoResultsException when every candidate is blocked`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(3)
 
-		val result = repository.next(AppSettings(blockedIds = setOf("w1", "w2", "w3")), portraitScreen)
+		val result = provider.next(AppSettings(), portraitScreen, setOf("w1", "w2", "w3"))
 		assertTrue(result.isFailure)
 		assertTrue(result.exceptionOrNull() is NoResultsException)
 	}
@@ -358,12 +318,8 @@ class WallhavenRepositoryTest {
 			)
 		} returns makePage(count = 1, currentPage = 2, lastPage = 2)
 
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
-
-		val result = repository.next(AppSettings(sorting = Sorting.VIEWS, blockedIds = setOf("w-1-1")), portraitScreen)
-		assertEquals("w-2-1", result.getOrNull()?.first?.id)
+		val result = provider.next(AppSettings(sorting = Sorting.VIEWS), portraitScreen, setOf("w-1-1"))
+		assertEquals("w-2-1", result.getOrNull()?.identity?.id)
 
 		coVerify(exactly = 1) {
 			wallhavenApiService.search(
@@ -376,11 +332,8 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `a multi-word query stays one phrase instead of splitting on whitespace`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(1)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		repository.next(AppSettings(searchQuery = "milky way"), portraitScreen)
+		provider.next(AppSettings(searchQuery = "milky way"), portraitScreen, emptySet())
 
 		coVerify(exactly = 1) {
 			wallhavenApiService.search(
@@ -393,11 +346,8 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `whitespace around an explicit delimiter is trimmed off each keyword`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(1)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
-		repository.next(AppSettings(searchQuery = "milky way, deep space"), portraitScreen)
+		provider.next(AppSettings(searchQuery = "milky way, deep space"), portraitScreen, emptySet())
 
 		coVerify(exactly = 1) {
 			wallhavenApiService.search(
@@ -417,13 +367,10 @@ class WallhavenRepositoryTest {
 	@Test
 	fun `comma semicolon and pipe delimiters also split the query`() = runTest {
 		coEvery { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns makePage(1)
-		coEvery { fileManager.download(any()) } answers {
-			Result.success(makeFile(firstArg<Wallpaper>().id))
-		}
 
 		for (delimiter in listOf(",", ";", "|")) {
-			val repo = WallhavenRepository(wallhavenApiService, fileManager)
-			repo.next(AppSettings(searchQuery = "ocean${delimiter}mountains"), portraitScreen)
+			val freshProvider = WallhavenProvider(wallhavenApiService)
+			freshProvider.next(AppSettings(searchQuery = "ocean${delimiter}mountains"), portraitScreen, emptySet())
 		}
 
 		coVerify(exactly = 6) { wallhavenApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallpaperFileManagerTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallpaperFileManagerTest.kt
@@ -13,7 +13,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import xyz.attacktive.wallhavend.domain.model.UnsupportedFormatException
 import xyz.attacktive.wallhavend.domain.model.Wallpaper
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 import xyz.attacktive.wallhavend.domain.service.WallpaperFileManager
 
 class WallpaperFileManagerTest {
@@ -34,17 +37,43 @@ class WallpaperFileManagerTest {
 		server.shutdown()
 	}
 
+	private fun makeWallpaper(id: String, path: String) = Wallpaper(
+		identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, id),
+		pageUrl = "https://wallhaven.cc/w/$id",
+		directUrl = server.url(path).toString(),
+		resolution = "1920x1080"
+	)
+
 	@Test
-	fun `download saves file with correct name`() = runTest {
+	fun `download names the file after the source-qualified id`() = runTest {
 		val body = Buffer().write(ByteArray(100) { it.toByte() })
 		server.enqueue(MockResponse().setBody(body).addHeader("Content-Type", "image/jpeg"))
 
-		val wallpaper = Wallpaper("abc123", "https://example.com", server.url("/abc.jpg").toString(), "1920x1080", "image/jpeg")
-		val result = manager.download(wallpaper)
+		val result = manager.download(makeWallpaper("abc123", "/abc.jpg"))
 
 		assertTrue(result.isSuccess)
-		assertEquals("abc123.jpg", result.getOrNull()?.name)
+		assertEquals("wallhaven_abc123.jpg", result.getOrNull()?.name)
 		assertTrue(result.getOrNull()?.exists() == true)
+	}
+
+	@Test
+	fun `the extension comes from what the server sent, not from the url`() = runTest {
+		val body = Buffer().write(ByteArray(100) { it.toByte() })
+		server.enqueue(MockResponse().setBody(body).addHeader("Content-Type", "image/png"))
+
+		val result = manager.download(makeWallpaper("abc123", "/abc"))
+
+		assertEquals("wallhaven_abc123.png", result.getOrNull()?.name)
+	}
+
+	@Test
+	fun `download rejects a body that is not a jpeg or a png`() = runTest {
+		val body = Buffer().write(ByteArray(100) { it.toByte() })
+		server.enqueue(MockResponse().setBody(body).addHeader("Content-Type", "image/gif"))
+
+		val result = manager.download(makeWallpaper("abc123", "/abc.gif"))
+
+		assertTrue(result.exceptionOrNull() is UnsupportedFormatException)
 	}
 
 	@Test
@@ -132,6 +161,22 @@ class WallpaperFileManagerTest {
 
 		assertEquals(listOf("pin.jpg"), kept.map { it.name })
 		assertTrue(pinned.exists())
+		assertTrue(!rotating.exists())
+	}
+
+	@Test
+	fun `trimToSize keeps a file pinned under either spelling of its id`() {
+		val wallpapersDir = File(tmpFolder.root, "wallpapers").also { it.mkdirs() }
+		val legacy = File(wallpapersDir, "legacy.jpg").also { it.writeText("data") }
+		val qualified = File(wallpapersDir, "wallhaven_fresh.jpg").also { it.writeText("data") }
+		val rotating = File(wallpapersDir, "wallhaven_rot.jpg").also { it.writeText("data") }
+
+		// A pin made before wallpapers were qualified is bare; one made after is qualified. Both must hold.
+		val kept = manager.trimToSize(0, setOf("legacy", "wallhaven_fresh"))
+
+		assertEquals(setOf("legacy.jpg", "wallhaven_fresh.jpg"), kept.map { it.name }.toSet())
+		assertTrue(legacy.exists())
+		assertTrue(qualified.exists())
 		assertTrue(!rotating.exists())
 	}
 

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallpaperIdentityTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallpaperIdentityTest.kt
@@ -1,0 +1,83 @@
+package xyz.attacktive.wallhavend
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
+
+class WallpaperIdentityTest {
+	@Test
+	fun `qualified prefixes the id with its source`() {
+		val identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, "abc123")
+
+		assertEquals("wallhaven_abc123", identity.qualified)
+	}
+
+	@Test
+	fun `a file name is the qualified id plus the extension`() {
+		val identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, "abc123")
+
+		assertEquals("wallhaven_abc123.jpg", identity.toFileName("jpg"))
+	}
+
+	@Test
+	fun `parse round-trips the qualified form`() {
+		val identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, "abc123")
+
+		assertEquals(identity, WallpaperIdentity.parse(identity.qualified))
+	}
+
+	@Test
+	fun `parse reads a bare id as Wallhaven, which is what carries older installs over`() {
+		val identity = WallpaperIdentity.parse("abc123")
+
+		assertEquals(WallpaperSource.WALLHAVEN, identity.source)
+		assertEquals("abc123", identity.id)
+	}
+
+	@Test
+	fun `parse keeps an unrecognised prefix as part of the id rather than inventing a source`() {
+		val identity = WallpaperIdentity.parse("someday_abc123")
+
+		assertEquals(WallpaperSource.WALLHAVEN, identity.source)
+		assertEquals("someday_abc123", identity.id)
+	}
+
+	@Test
+	fun `parse ignores a source prefix with nothing after it`() {
+		val identity = WallpaperIdentity.parse("wallhaven_")
+
+		assertEquals("wallhaven_", identity.id)
+	}
+
+	@Test
+	fun `a legacy file name and its qualified form are the same wallpaper`() {
+		assertEquals(WallpaperIdentity.parse("abc123"), WallpaperIdentity.parse("wallhaven_abc123"))
+	}
+
+	@Test
+	fun `matches accepts both the qualified and the legacy bare form`() {
+		val identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, "abc123")
+
+		assertTrue(identity.matches(setOf("wallhaven_abc123")))
+		assertTrue(identity.matches(setOf("abc123")))
+		assertFalse(identity.matches(setOf("wallhaven_def456", "def456")))
+	}
+
+	@Test
+	fun `persistedForms covers every spelling a removal has to clear`() {
+		val identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, "abc123")
+
+		assertEquals(setOf("wallhaven_abc123", "abc123"), identity.persistedForms)
+	}
+
+	@Test
+	fun `a Wallhaven identity points at its own page and thumbnail`() {
+		val identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, "abc123")
+
+		assertEquals("https://wallhaven.cc/w/abc123", identity.pageUrl)
+		assertEquals("https://th.wallhaven.cc/lg/ab/abc123.jpg", identity.thumbnailUrl)
+	}
+}

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallpaperRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallpaperRepositoryTest.kt
@@ -1,0 +1,134 @@
+package xyz.attacktive.wallhavend
+
+import java.io.File
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import io.mockk.coEvery
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import xyz.attacktive.wallhavend.domain.model.AppSettings
+import xyz.attacktive.wallhavend.domain.model.NoResultsException
+import xyz.attacktive.wallhavend.domain.model.ScreenInfo
+import xyz.attacktive.wallhavend.domain.model.Wallpaper
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
+import xyz.attacktive.wallhavend.domain.repository.WallpaperProvider
+import xyz.attacktive.wallhavend.domain.repository.WallpaperRepository
+import xyz.attacktive.wallhavend.domain.service.WallpaperFileManager
+
+class WallpaperRepositoryTest {
+	private val fileManager = mockk<WallpaperFileManager>()
+
+	private val screen = ScreenInfo("9x16", 1080, 2400)
+
+	/**
+	 * Sources are consulted in random order, so a single run may or may not exercise the fall-back path.
+	 * The assertions hold for every order, and repeating makes it near-certain that each one gets covered.
+	 */
+	private val shuffleAttempts = 25
+
+	private fun makeWallpaper(id: String) = Wallpaper(
+		identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, id),
+		pageUrl = "https://wallhaven.cc/w/$id",
+		directUrl = "https://cdn/w/$id.jpg",
+		resolution = "1920x1080"
+	)
+
+	private fun createRepository(vararg providers: WallpaperProvider) = WallpaperRepository(providers.toSet(), fileManager)
+
+	@Test
+	fun `next returns the picked wallpaper alongside its downloaded file`() = runTest {
+		val wallpaper = makeWallpaper("abc123")
+		coEvery { fileManager.download(wallpaper) } returns Result.success(File("/tmp/wallhaven_abc123.jpg"))
+
+		val repository = createRepository(FakeWallpaperProvider(Result.success(wallpaper)))
+		val result = repository.next(AppSettings(), screen)
+
+		assertTrue(result.isSuccess)
+		assertEquals(wallpaper, result.getOrNull()?.first)
+		assertEquals("wallhaven_abc123.jpg", result.getOrNull()?.second?.name)
+	}
+
+	@Test
+	fun `a source that fails to search hands over to another one`() = runTest {
+		val wallpaper = makeWallpaper("good")
+		coEvery { fileManager.download(wallpaper) } returns Result.success(File("/tmp/wallhaven_good.jpg"))
+
+		val repository = createRepository(
+			FakeWallpaperProvider(Result.failure(IOException("search is down"))),
+			FakeWallpaperProvider(Result.success(wallpaper))
+		)
+
+		repeat(shuffleAttempts) {
+			assertEquals(wallpaper, repository.next(AppSettings(), screen).getOrNull()?.first)
+		}
+	}
+
+	@Test
+	fun `a source whose download fails hands over to another one`() = runTest {
+		val rotted = makeWallpaper("rotted")
+		val alive = makeWallpaper("alive")
+		coEvery { fileManager.download(rotted) } returns Result.failure(IOException("HTTP 404"))
+		coEvery { fileManager.download(alive) } returns Result.success(File("/tmp/wallhaven_alive.jpg"))
+
+		val repository = createRepository(
+			FakeWallpaperProvider(Result.success(rotted)),
+			FakeWallpaperProvider(Result.success(alive))
+		)
+
+		repeat(shuffleAttempts) {
+			assertEquals(alive, repository.next(AppSettings(), screen).getOrNull()?.first)
+		}
+	}
+
+	@Test
+	fun `an update fails only once every source has`() = runTest {
+		val repository = createRepository(
+			FakeWallpaperProvider(Result.failure(NoResultsException())),
+			FakeWallpaperProvider(Result.failure(NoResultsException()))
+		)
+
+		val result = repository.next(AppSettings(), screen)
+
+		assertTrue(result.isFailure)
+		assertTrue(result.exceptionOrNull() is NoResultsException)
+	}
+
+	@Test
+	fun `an empty pool from one source loses the error report to a real failure from another`() = runTest {
+		val repository = createRepository(
+			FakeWallpaperProvider(Result.failure(NoResultsException())),
+			FakeWallpaperProvider(Result.failure(IOException("search is down")))
+		)
+
+		repeat(shuffleAttempts) {
+			assertTrue(repository.next(AppSettings(), screen).exceptionOrNull() is IOException)
+		}
+	}
+
+	@Test
+	fun `blocked ids reach a source stripped of the qualifying prefix`() = runTest {
+		val provider = FakeWallpaperProvider(Result.failure(NoResultsException()))
+		val blockedIds = setOf("wallhaven_abc123", "def456")
+
+		createRepository(provider).next(AppSettings(blockedIds = blockedIds), screen)
+
+		assertEquals(setOf("abc123", "def456"), provider.receivedBlockedIds)
+	}
+}
+
+/** Stands in for a source: hands back a fixed outcome and records the blocked ids it was given. */
+private class FakeWallpaperProvider(private val result: Result<Wallpaper>): WallpaperProvider {
+	override val source = WallpaperSource.WALLHAVEN
+
+	var receivedBlockedIds: Set<String>? = null
+		private set
+
+	override suspend fun next(settings: AppSettings, screenInfo: ScreenInfo, blockedIds: Set<String>): Result<Wallpaper> {
+		receivedBlockedIds = blockedIds
+
+		return result
+	}
+}


### PR DESCRIPTION
Identity was the raw Wallhaven id, so a second source would have collided with it on disk and in the pinned/blocked sets. WallpaperIdentity is now the single encode/decode point: files are named `wallhaven_<id>.<ext>`, pins and blocks persist that same qualified form, and parse() also accepts bare ids so existing files, pins and blocks keep working with no DataStore migration and nothing renamed on disk.

WallhavenRepository becomes WallhavenProvider behind a WallpaperProvider interface, with downloading lifted out into a new WallpaperRepository that blends every registered source: it consults them in random order and falls back to the next when a search or a download fails, reporting an error only once all of them have.

The downloaded file's extension now comes from the response Content-Type rather than from search metadata, since not every source reports a file type.