### PR TITLE
feature: add Openverse as a second wallpaper source

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/data/api/OpenverseApiService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/data/api/OpenverseApiService.kt
@@ -1,0 +1,21 @@
+package xyz.attacktive.wallhavend.data.api
+
+import retrofit2.http.GET
+import retrofit2.http.Query
+import xyz.attacktive.wallhavend.data.api.dto.OpenverseSearchResponseDto
+
+interface OpenverseApiService {
+	/** The trailing slash is load-bearing: without it the API answers 301 to the slashed form, costing a round trip on every search. */
+	@GET("v1/images/")
+	suspend fun search(
+		@Query("q") query: String?,
+		@Query("license") license: String,
+		@Query("source") source: String,
+		@Query("extension") extension: String,
+		@Query("aspect_ratio") aspectRatio: String,
+		@Query("size") size: String?,
+		@Query("mature") mature: Boolean,
+		@Query("page") page: Int,
+		@Query("page_size") pageSize: Int
+	): OpenverseSearchResponseDto
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/data/api/WallhavenApiService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/data/api/WallhavenApiService.kt
@@ -2,7 +2,7 @@ package xyz.attacktive.wallhavend.data.api
 
 import retrofit2.http.GET
 import retrofit2.http.Query
-import xyz.attacktive.wallhavend.data.api.dto.SearchResponseDto
+import xyz.attacktive.wallhavend.data.api.dto.WallhavenSearchResponseDto
 
 interface WallhavenApiService {
 	@GET("search")
@@ -18,5 +18,5 @@ interface WallhavenApiService {
 		@Query("page") page: Int?,
 		@Query("colors") colors: String?,
 		@Query("apikey") apiKey: String?
-	): SearchResponseDto
+	): WallhavenSearchResponseDto
 }

--- a/app/src/main/java/xyz/attacktive/wallhavend/data/api/dto/OpenverseImageDto.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/data/api/dto/OpenverseImageDto.kt
@@ -1,0 +1,33 @@
+package xyz.attacktive.wallhavend.data.api.dto
+
+import kotlinx.serialization.Serializable
+import android.annotation.SuppressLint
+import xyz.attacktive.wallhavend.domain.model.Wallpaper
+import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
+
+/**
+ * One Openverse result.
+ * [width] and [height] are what make the resolution check possible at all: Openverse's own `size` filter is a coarse small/medium/large bucket, so "at least as large as the screen" has to be decided here rather than in the query.
+ * Both are nullable because the index doesn't always know them, and a result that can't prove its size is treated as too small.
+ * [url] is nullable because [the Openverse schema does not guarantee it](https://api.openverse.org/v1/#schema_image); records without a direct URL can't be downloaded and are skipped.
+ */
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
+data class OpenverseImageDto(
+	val id: String,
+	val url: String? = null,
+	val width: Int? = null,
+	val height: Int? = null
+)
+
+/** [WallpaperIdentity.pageUrl] is the Openverse entry for the id; Openverse only indexes what other sites host, so the origin page stays out of the model. */
+fun OpenverseImageDto.toDomain() = Wallpaper(
+	identity = WallpaperIdentity(WallpaperSource.OPENVERSE, id),
+	directUrl = checkNotNull(url),
+	resolution = if (width != null && height != null) {
+		"${width}x$height"
+	} else {
+		""
+	}
+)

--- a/app/src/main/java/xyz/attacktive/wallhavend/data/api/dto/OpenverseSearchResponseDto.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/data/api/dto/OpenverseSearchResponseDto.kt
@@ -1,0 +1,13 @@
+package xyz.attacktive.wallhavend.data.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import android.annotation.SuppressLint
+
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
+data class OpenverseSearchResponseDto(
+	@SerialName("page_count") val pageCount: Int,
+	val page: Int,
+	val results: List<OpenverseImageDto>
+)

--- a/app/src/main/java/xyz/attacktive/wallhavend/data/api/dto/WallhavenSearchResponseDto.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/data/api/dto/WallhavenSearchResponseDto.kt
@@ -6,11 +6,11 @@ import android.annotation.SuppressLint
 
 @SuppressLint("UnsafeOptInUsageError")
 @Serializable
-data class SearchResponseDto(val data: List<WallpaperDto>, val meta: MetaDto)
+data class WallhavenSearchResponseDto(val data: List<WallhavenWallpaperDto>, val meta: WallhavenMetaDto)
 
 @SuppressLint("UnsafeOptInUsageError")
 @Serializable
-data class MetaDto(
+data class WallhavenMetaDto(
 	@SerialName("current_page") val currentPage: Int,
 	@SerialName("last_page") val lastPage: Int,
 	@SerialName("per_page") val perPage: Int,

--- a/app/src/main/java/xyz/attacktive/wallhavend/data/api/dto/WallhavenWallpaperDto.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/data/api/dto/WallhavenWallpaperDto.kt
@@ -8,11 +8,10 @@ import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 
 @SuppressLint("UnsafeOptInUsageError")
 @Serializable
-data class WallpaperDto(val id: String, val url: String, val path: String, val resolution: String)
+data class WallhavenWallpaperDto(val id: String, val path: String, val resolution: String)
 
-fun WallpaperDto.toDomain() = Wallpaper(
+fun WallhavenWallpaperDto.toDomain() = Wallpaper(
 	identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, id),
-	pageUrl = url,
 	directUrl = path,
 	resolution = resolution
 )

--- a/app/src/main/java/xyz/attacktive/wallhavend/di/NetworkModule.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package xyz.attacktive.wallhavend.di
 
 import java.util.concurrent.TimeUnit
+import javax.inject.Qualifier
 import javax.inject.Singleton
 import kotlinx.serialization.json.Json
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -13,7 +14,16 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import xyz.attacktive.wallhavend.BuildConfig
+import xyz.attacktive.wallhavend.data.api.OpenverseApiService
 import xyz.attacktive.wallhavend.data.api.WallhavenApiService
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class WallhavenRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class OpenverseRetrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -40,16 +50,28 @@ object NetworkModule {
 		}
 		.build()
 
+	/** The two APIs differ only by base URL, so they share the client and the converter and are told apart by a qualifier rather than by a subclass. */
 	@Provides
 	@Singleton
-	fun provideRetrofit(okHttpClient: OkHttpClient, json: Json): Retrofit = Retrofit.Builder()
-		.baseUrl("https://wallhaven.cc/api/v1/")
-		.client(okHttpClient)
-		.addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-		.build()
+	@WallhavenRetrofit
+	fun provideWallhavenRetrofit(okHttpClient: OkHttpClient, json: Json) = retrofitFor("https://wallhaven.cc/api/v1/", okHttpClient, json)
 
 	@Provides
 	@Singleton
-	fun provideWallhavenApiService(retrofit: Retrofit): WallhavenApiService =
-		retrofit.create(WallhavenApiService::class.java)
+	@OpenverseRetrofit
+	fun provideOpenverseRetrofit(okHttpClient: OkHttpClient, json: Json) = retrofitFor("https://api.openverse.org/", okHttpClient, json)
+
+	@Provides
+	@Singleton
+	fun provideWallhavenApiService(@WallhavenRetrofit retrofit: Retrofit): WallhavenApiService = retrofit.create(WallhavenApiService::class.java)
+
+	@Provides
+	@Singleton
+	fun provideOpenverseApiService(@OpenverseRetrofit retrofit: Retrofit): OpenverseApiService = retrofit.create(OpenverseApiService::class.java)
 }
+
+private fun retrofitFor(baseUrl: String, okHttpClient: OkHttpClient, json: Json) = Retrofit.Builder()
+	.baseUrl(baseUrl)
+	.client(okHttpClient)
+	.addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+	.build()

--- a/app/src/main/java/xyz/attacktive/wallhavend/di/RepositoryModule.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/di/RepositoryModule.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import okhttp3.OkHttpClient
+import xyz.attacktive.wallhavend.domain.repository.OpenverseProvider
 import xyz.attacktive.wallhavend.domain.repository.WallhavenProvider
 import xyz.attacktive.wallhavend.domain.repository.WallpaperProvider
 import xyz.attacktive.wallhavend.domain.service.WallpaperFileManager
@@ -38,4 +39,8 @@ object RepositoryModule {
 	@Provides
 	@IntoSet
 	fun provideWallhavenProvider(wallhavenProvider: WallhavenProvider): WallpaperProvider = wallhavenProvider
+
+	@Provides
+	@IntoSet
+	fun provideOpenverseProvider(openverseProvider: OpenverseProvider): WallpaperProvider = openverseProvider
 }

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/AppSettings.kt
@@ -2,14 +2,18 @@ package xyz.attacktive.wallhavend.domain.model
 
 import kotlin.math.abs
 import xyz.attacktive.wallhavend.domain.model.query.Category
+import xyz.attacktive.wallhavend.domain.model.query.LicenseFilter
 import xyz.attacktive.wallhavend.domain.model.query.Purity
 import xyz.attacktive.wallhavend.domain.model.query.Sorting
 import xyz.attacktive.wallhavend.domain.model.query.ToplistRange
 
 data class AppSettings(
+	/** Wallhaven alone by default, so an install that predates a second source keeps rotating exactly what it always did until the user opts in. */
+	val enabledSources: Set<WallpaperSource> = setOf(WallpaperSource.WALLHAVEN),
 	val searchQuery: String = "",
 	val categories: Set<Category> = setOf(Category.GENERAL),
 	val purity: Set<Purity> = setOf(Purity.SFW),
+	val licenseFilter: LicenseFilter = LicenseFilter.PUBLIC_DOMAIN,
 	val updateIntervalMinutes: Int = 60,
 	val wallpaperTarget: WallpaperTarget = WallpaperTarget.HOME,
 	val rotationMode: RotationMode = RotationMode.FRESH_WIFI,
@@ -27,6 +31,18 @@ data class AppSettings(
 
 val UPDATE_INTERVAL_OPTIONS = listOf(1, 5, 15, 30, 60, 180, 360, 1440)
 val POOL_SIZE_OPTIONS = listOf(1, 5, 10, 25, 50)
+
+private val KEYWORD_DELIMITERS = Regex("[,;|]+")
+
+/**
+ * The search query as the separate searches every provider fans out over.
+ * Only explicit delimiters split it, never whitespace.
+ * Splitting on whitespace turned a phrase into unrelated searches that were then merged: "red car" became "red" (1690 portrait results) plus "car" (508) instead of the 76 that actually match both.
+ * Trimming each keyword is what the delimiter class used to do for free, back when it also absorbed the spaces around a comma.
+ */
+val AppSettings.keywords get() = searchQuery.split(KEYWORD_DELIMITERS)
+	.map { it.trim() }
+	.filter { it.isNotBlank() }
 
 /**
  * Ratios with meaningful content on Wallhaven (verified by querying meta.total per ratio).

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/Wallpaper.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/Wallpaper.kt
@@ -1,3 +1,7 @@
 package xyz.attacktive.wallhavend.domain.model
 
-data class Wallpaper(val identity: WallpaperIdentity, val pageUrl: String, val directUrl: String, val resolution: String)
+/**
+ * A downloaded wallpaper about to hit disk.
+ * [directUrl] is what gets fetched; the page to visit is [WallpaperIdentity.pageUrl], which each source's id can reconstruct on demand.
+ */
+data class Wallpaper(val identity: WallpaperIdentity, val directUrl: String, val resolution: String)

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/WallpaperIdentity.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/WallpaperIdentity.kt
@@ -10,19 +10,23 @@ data class WallpaperIdentity(val source: WallpaperSource, val id: String) {
 	/** The origin site's page for this wallpaper. */
 	val pageUrl get() = when (source) {
 		WallpaperSource.WALLHAVEN -> "https://wallhaven.cc/w/$id"
+		WallpaperSource.OPENVERSE -> "https://openverse.org/image/$id"
 	}
 
 	/** A remote thumbnail, for wallpapers with no local file left to show — a blocked one, say. */
 	val thumbnailUrl get() = when (source) {
 		WallpaperSource.WALLHAVEN -> "https://th.wallhaven.cc/lg/${id.take(2)}/$id.jpg"
+		WallpaperSource.OPENVERSE -> "https://api.openverse.org/v1/images/$id/thumb/"
 	}
 
 	/**
 	 * Every form this wallpaper can appear as in a persisted id set.
 	 * Installs predating source-qualified ids stored bare Wallhaven ids, so lookups have to accept that form and removals have to clear it.
+	 * Only Wallhaven carries that baggage: every other source arrived after ids were qualified, so it has just the one spelling.
 	 */
 	val persistedForms get() = when (source) {
 		WallpaperSource.WALLHAVEN -> setOf(qualified, id)
+		WallpaperSource.OPENVERSE -> setOf(qualified)
 	}
 
 	fun toFileName(extension: String) = "$qualified.$extension"

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/WallpaperSource.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/WallpaperSource.kt
@@ -1,11 +1,21 @@
 package xyz.attacktive.wallhavend.domain.model
 
+import androidx.annotation.StringRes
+import xyz.attacktive.wallhavend.R
+
 /**
  * Where a wallpaper came from.
  * [key] is the persisted discriminator, so renaming one orphans every id already stored on the device.
+ * [attributionRes] and [homeUrl] are what the source asks to be credited with — Openverse's terms require saying the app is not endorsed by them, so the credit is an obligation rather than a courtesy.
  */
-enum class WallpaperSource(val key: String) {
-	WALLHAVEN("wallhaven");
+enum class WallpaperSource(
+	val key: String,
+	@get:StringRes val nameRes: Int,
+	@get:StringRes val attributionRes: Int,
+	val homeUrl: String
+) {
+	WALLHAVEN("wallhaven", R.string.source_wallhaven, R.string.settings_powered_by_wallhaven, "https://wallhaven.cc"),
+	OPENVERSE("openverse", R.string.source_openverse, R.string.settings_powered_by_openverse, "https://openverse.org");
 
 	companion object {
 		fun fromKey(key: String) = entries.firstOrNull { it.key == key }

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/query/LicenseFilter.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/query/LicenseFilter.kt
@@ -1,0 +1,14 @@
+package xyz.attacktive.wallhavend.domain.model.query
+
+import androidx.annotation.StringRes
+import xyz.attacktive.wallhavend.R
+
+/**
+ * How permissive an Openverse result's licence may be, narrowest first.
+ * Each tier names its licences outright instead of leaning on Openverse's `license_type` grouping, so the tiers stay strictly nested — widening the filter can only ever add licences, never swap one out.
+ */
+enum class LicenseFilter(val apiValue: String, @get:StringRes val nameRes: Int) {
+	PUBLIC_DOMAIN("cc0,pdm", R.string.license_public_domain),
+	PERMISSIVE("cc0,pdm,by", R.string.license_permissive),
+	ANY_COMMERCIAL("cc0,pdm,by,by-sa,by-nd", R.string.license_any_commercial)
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/OpenverseProvider.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/OpenverseProvider.kt
@@ -1,0 +1,193 @@
+package xyz.attacktive.wallhavend.domain.repository
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import xyz.attacktive.wallhavend.data.api.OpenverseApiService
+import xyz.attacktive.wallhavend.data.api.dto.OpenverseImageDto
+import xyz.attacktive.wallhavend.data.api.dto.toDomain
+import xyz.attacktive.wallhavend.domain.model.AppSettings
+import xyz.attacktive.wallhavend.domain.model.NoResultsException
+import xyz.attacktive.wallhavend.domain.model.ScreenInfo
+import xyz.attacktive.wallhavend.domain.model.Wallpaper
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
+import xyz.attacktive.wallhavend.domain.model.keywords
+import xyz.attacktive.wallhavend.domain.model.query.Purity
+
+@Singleton
+class OpenverseProvider @Inject constructor(private val openverseApiService: OpenverseApiService): WallpaperProvider {
+	override val source = WallpaperSource.OPENVERSE
+
+	private val mutex = Mutex()
+	private var cache = ArrayDeque<OpenverseImageDto>()
+	private var cacheKey: SearchKey? = null
+	private var pageCount: Int? = null
+
+	private data class SearchKey(
+		val keywords: List<String>,
+		val license: String,
+		val aspectRatio: String,
+		val size: String?,
+		val mature: Boolean,
+		val minimumWidth: Int?,
+		val minimumHeight: Int?
+	)
+
+	private fun AppSettings.toSearchKey(screenInfo: ScreenInfo) = SearchKey(
+		keywords = keywords,
+		license = licenseFilter.apiValue,
+		aspectRatio = screenInfo.openverseAspectRatio(),
+		size = if (avoidBlurryWallpapers) {
+			"large"
+		} else {
+			null
+		},
+		// Openverse's `mature` widens the results rather than restricting them to explicit ones, so it follows the one purity that means the same thing.
+		mature = Purity.NSFW in purity,
+		minimumWidth = if (avoidBlurryWallpapers) {
+			screenInfo.width
+		} else {
+			null
+		},
+		minimumHeight = if (avoidBlurryWallpapers) {
+			screenInfo.height
+		} else {
+			null
+		}
+	)
+
+	override suspend fun next(settings: AppSettings, screenInfo: ScreenInfo, blockedIds: Set<String>): Result<Wallpaper> = mutex.withLock {
+		val key = settings.toSearchKey(screenInfo)
+		if (key != cacheKey) {
+			cache.clear()
+			cacheKey = key
+			pageCount = null
+		}
+
+		val selection = runCatching { selectNext(key, blockedIds) }
+		val dto = selection.getOrElse { exception -> return@withLock Result.failure(exception) }
+			?: return@withLock Result.failure(NoResultsException())
+
+		Result.success(dto.toDomain())
+	}
+
+	/**
+	 * Blocked wallpapers, records without a downloadable URL, and results too small for the screen are dropped after the fetch, so a page can arrive full and still leave nothing to pick.
+	 * That earns another page rather than a "no results"; only a page the API returned empty — or too many fruitless tries — gives up.
+	 */
+	private suspend fun selectNext(key: SearchKey, blockedIds: Set<String>): OpenverseImageDto? {
+		val maxRefetches = 5
+		var refetches = 0
+
+		while (true) {
+			while (cache.isNotEmpty() && cache.first().id in blockedIds) {
+				cache.removeFirst()
+			}
+
+			if (cache.isNotEmpty()) {
+				return cache.removeFirst()
+			}
+
+			if (refetches >= maxRefetches) {
+				return null
+			}
+
+			refetches++
+			val fetchedCount = refetch(key).getOrThrow()
+			if (fetchedCount == 0) {
+				return null
+			}
+		}
+	}
+
+	private suspend fun refetch(key: SearchKey) = runCatching {
+		val effectiveKeywords: List<String?> = key.keywords.ifEmpty { listOf(null) }
+		val page = pageToFetch()
+
+		val responses = coroutineScope {
+			effectiveKeywords
+				.map { keyword ->
+					async {
+						openverseApiService.search(
+							query = keyword,
+							license = key.license,
+							source = SOURCE_ALLOWLIST,
+							extension = EXTENSIONS,
+							aspectRatio = key.aspectRatio,
+							size = key.size,
+							mature = key.mature,
+							page = page,
+							pageSize = PAGE_SIZE
+						)
+					}
+				}
+				.awaitAll()
+		}
+
+		// The narrowest keyword decides how deep the next page may go, since one page number is shared by the whole fan-out.
+		pageCount = responses.minOf { it.pageCount }
+
+		val results = responses.flatMap { it.results }
+
+		cache = ArrayDeque(
+			results.filter { it.url != null && key.admits(it) }
+				.shuffled()
+		)
+
+		results.size
+	}
+
+	/**
+	 * Openverse has no random sort, so variety comes from where in the result set the fetch lands.
+	 * The first fetch has to be page 1 — nothing yet says how many pages there are — and every one after it picks at random within reach.
+	 */
+	private fun pageToFetch(): Int {
+		val knownPageCount = pageCount ?: return 1
+		val reachablePages = minOf(knownPageCount, MAX_DEPTH / PAGE_SIZE)
+
+		return (1..reachablePages.coerceAtLeast(1)).random()
+	}
+
+	/** Openverse's own `size` filter is a coarse small/medium/large bucket, so "at least as large as the screen" is settled here; a result that never reported its dimensions can't prove it qualifies. */
+	private fun SearchKey.admits(image: OpenverseImageDto): Boolean {
+		if (minimumWidth == null || minimumHeight == null) {
+			return true
+		}
+
+		val wideEnough = (image.width ?: 0) >= minimumWidth
+		val tallEnough = (image.height ?: 0) >= minimumHeight
+
+		return wideEnough && tallEnough
+	}
+
+	companion object {
+		/** Openverse indexes 52 sources and most are archival — herbarium sheets and scanned postcards make poor wallpapers — so the query names the ones that don't. */
+		private const val SOURCE_ALLOWLIST = "flickr,wikimedia,nasa,spacex,rawpixel,stocksnap"
+
+		/** WallpaperFileManager only accepts JPEG and PNG, so anything else is ruled out server-side instead of downloaded and thrown away. */
+		private const val EXTENSIONS = "jpg,png"
+
+		/**
+		 * Anonymous requests may ask for 20 results at a time and reach 240 results deep.
+		 * An API key would lift both; the app deliberately doesn't carry one.
+		 */
+		private const val PAGE_SIZE = 20
+		private const val MAX_DEPTH = 240
+	}
+}
+
+/** Openverse buckets every ratio into three, so the screen's own has to be rounded to the nearest of them. */
+private fun ScreenInfo.openverseAspectRatio(): String {
+	val squareTolerance = 0.05f
+	val ratio = width.toFloat() / height
+
+	return when {
+		ratio < 1 - squareTolerance -> "tall"
+		ratio > 1 + squareTolerance -> "wide"
+		else -> "square"
+	}
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/SettingsRepository.kt
@@ -15,8 +15,10 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.query.Category
+import xyz.attacktive.wallhavend.domain.model.query.LicenseFilter
 import xyz.attacktive.wallhavend.domain.model.query.Purity
 import xyz.attacktive.wallhavend.domain.model.query.Sorting
 import xyz.attacktive.wallhavend.domain.model.query.ToplistRange
@@ -25,9 +27,11 @@ import xyz.attacktive.wallhavend.util.AppLogger
 @Singleton
 class SettingsRepository @Inject constructor(private val dataStore: DataStore<Preferences>, private val logger: AppLogger) {
 	private object Keys {
+		val ENABLED_SOURCES = stringSetPreferencesKey("enabled_sources")
 		val SEARCH_QUERY = stringPreferencesKey("search_query")
 		val CATEGORIES = stringSetPreferencesKey("categories")
 		val PURITY = stringSetPreferencesKey("purity")
+		val LICENSE_FILTER = stringPreferencesKey("license_filter")
 		val UPDATE_INTERVAL_MINUTES = intPreferencesKey("update_interval_minutes")
 		val WALLPAPER_TARGET = stringPreferencesKey("wallpaper_target")
 
@@ -51,6 +55,10 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 
 	val settings = dataStore.data
 		.map { preferences -> AppSettings(
+				enabledSources = (preferences[Keys.ENABLED_SOURCES] ?: setOf(WallpaperSource.WALLHAVEN.key))
+					.mapNotNull { WallpaperSource.fromKey(it) }
+					.toSet()
+					.ifEmpty { setOf(WallpaperSource.WALLHAVEN) },
 				searchQuery = preferences[Keys.SEARCH_QUERY] ?: "",
 				categories = (preferences[Keys.CATEGORIES] ?: setOf("GENERAL"))
 					.mapNotNull { runCatching { Category.valueOf(it) }.getOrNull() }
@@ -60,6 +68,9 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 					.mapNotNull { runCatching { Purity.valueOf(it) }.getOrNull() }
 					.toSet()
 					.ifEmpty { setOf(Purity.SFW) },
+				licenseFilter = preferences[Keys.LICENSE_FILTER]
+					?.let { runCatching { LicenseFilter.valueOf(it) }.getOrNull() }
+					?: LicenseFilter.PUBLIC_DOMAIN,
 				updateIntervalMinutes = preferences[Keys.UPDATE_INTERVAL_MINUTES] ?: 60,
 				wallpaperTarget = preferences[Keys.WALLPAPER_TARGET]
 					?.let { runCatching { WallpaperTarget.valueOf(it) }.getOrNull() }
@@ -85,6 +96,11 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 		logger.debug(TAG, "save: ${settings.redactedForLog()}")
 
 		dataStore.edit { preferences ->
+			// Sources persist by their stable key rather than their enum name, for the same reason wallpaper ids do: the stored value has to outlive any renaming in the code.
+			preferences[Keys.ENABLED_SOURCES] = settings.enabledSources
+				.map { it.key }
+				.toSet()
+
 			preferences[Keys.SEARCH_QUERY] = settings.searchQuery
 
 			preferences[Keys.CATEGORIES] = settings.categories
@@ -95,6 +111,7 @@ class SettingsRepository @Inject constructor(private val dataStore: DataStore<Pr
 				.map { it.name }
 				.toSet()
 
+			preferences[Keys.LICENSE_FILTER] = settings.licenseFilter.name
 			preferences[Keys.UPDATE_INTERVAL_MINUTES] = settings.updateIntervalMinutes
 			preferences[Keys.WALLPAPER_TARGET] = settings.wallpaperTarget.name
 			preferences[Keys.ROTATION_MODE] = settings.rotationMode.name

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenProvider.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallhavenProvider.kt
@@ -8,13 +8,14 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import xyz.attacktive.wallhavend.data.api.WallhavenApiService
-import xyz.attacktive.wallhavend.data.api.dto.WallpaperDto
+import xyz.attacktive.wallhavend.data.api.dto.WallhavenWallpaperDto
 import xyz.attacktive.wallhavend.data.api.dto.toDomain
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.NoResultsException
 import xyz.attacktive.wallhavend.domain.model.ScreenInfo
 import xyz.attacktive.wallhavend.domain.model.Wallpaper
 import xyz.attacktive.wallhavend.domain.model.WallpaperSource
+import xyz.attacktive.wallhavend.domain.model.keywords
 import xyz.attacktive.wallhavend.domain.model.query.Sorting
 import xyz.attacktive.wallhavend.domain.model.query.toBitString
 
@@ -23,7 +24,7 @@ class WallhavenProvider @Inject constructor(private val wallhavenApiService: Wal
 	override val source = WallpaperSource.WALLHAVEN
 
 	private val mutex = Mutex()
-	private var cache = ArrayDeque<WallpaperDto>()
+	private var cache = ArrayDeque<WallhavenWallpaperDto>()
 	private var cacheKey: SearchKey? = null
 	private var currentPage = 1
 	private var lastPage = 1
@@ -40,36 +41,25 @@ class WallhavenProvider @Inject constructor(private val wallhavenApiService: Wal
 		val toplistRange: String?
 	)
 
-	private fun AppSettings.toSearchKey(screenInfo: ScreenInfo): SearchKey {
-		/*
-		 * Only explicit delimiters split the query, never whitespace.
-		 * Splitting on whitespace turned a phrase into unrelated searches that were then merged: "red car" became "red" (1690 portrait results) plus "car" (508) instead of the 76 that actually match both.
-		 * Trimming each keyword is what the delimiter class used to do for free, back when it also absorbed the spaces around a comma.
-		 */
-		val keywords = searchQuery.split(Regex("[,;|]+"))
-			.map { it.trim() }
-			.filter { it.isNotBlank() }
-
-		return SearchKey(
-			keywords = keywords,
-			categories = categories.toBitString(),
-			purity = purity.toBitString(),
-			ratios = screenInfo.aspectRatio,
-			atleast = if (avoidBlurryWallpapers) {
-				"${screenInfo.width}x${screenInfo.height}"
-			} else {
-				null
-			},
-			colors = filterColor.ifBlank { null },
-			apiKey = apiKey.ifBlank { null },
-			sorting = sorting,
-			toplistRange = if (sorting == Sorting.TOPLIST) {
-				toplistRange.apiValue
-			} else {
-				null
-			}
-		)
-	}
+	private fun AppSettings.toSearchKey(screenInfo: ScreenInfo) = SearchKey(
+		keywords = keywords,
+		categories = categories.toBitString(),
+		purity = purity.toBitString(),
+		ratios = screenInfo.aspectRatio,
+		atleast = if (avoidBlurryWallpapers) {
+			"${screenInfo.width}x${screenInfo.height}"
+		} else {
+			null
+		},
+		colors = filterColor.ifBlank { null },
+		apiKey = apiKey.ifBlank { null },
+		sorting = sorting,
+		toplistRange = if (sorting == Sorting.TOPLIST) {
+			toplistRange.apiValue
+		} else {
+			null
+		}
+	)
 
 	override suspend fun next(settings: AppSettings, screenInfo: ScreenInfo, blockedIds: Set<String>): Result<Wallpaper> = mutex.withLock {
 		val key = settings.toSearchKey(screenInfo)
@@ -93,7 +83,7 @@ class WallhavenProvider @Inject constructor(private val wallhavenApiService: Wal
 	 * than giving up. A genuinely empty page (no results at all) stops immediately, and an all-blocked
 	 * search is bounded so it can't loop forever before falling back to NoResults.
 	 */
-	private suspend fun selectNext(key: SearchKey, blockedIds: Set<String>): WallpaperDto? {
+	private suspend fun selectNext(key: SearchKey, blockedIds: Set<String>): WallhavenWallpaperDto? {
 		val maxBlockedPageRefetches = 5
 		var refetches = 0
 

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallpaperRepository.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/WallpaperRepository.kt
@@ -12,7 +12,7 @@ import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 import xyz.attacktive.wallhavend.domain.service.WallpaperFileManager
 
 /**
- * Blends every registered source into one rotation.
+ * Blends every enabled source into one rotation.
  * Sources are tried in random order so none of them dominates, and one that fails to search or to download hands over to the next instead of failing the whole update — only an all-sources-failed run surfaces an error.
  */
 @Singleton
@@ -23,7 +23,10 @@ class WallpaperRepository @Inject constructor(
 	suspend fun next(settings: AppSettings, screenInfo: ScreenInfo): Result<Pair<Wallpaper, File>> {
 		val failures = mutableListOf<Throwable>()
 
-		for (provider in providers.shuffled()) {
+		val enabledProviders = providers.filter { it.source in settings.enabledSources }
+			.shuffled()
+
+		for (provider in enabledProviders) {
 			val blockedIds = blockedIdsFor(provider.source, settings.blockedIds)
 
 			val attempt = provider.next(settings, screenInfo, blockedIds)

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -47,6 +47,7 @@ import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.ScreenInfo
 import xyz.attacktive.wallhavend.domain.model.UnsupportedFormatException
 import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.closestAspectRatio
 import xyz.attacktive.wallhavend.domain.repository.ServiceStateRepository
@@ -168,8 +169,8 @@ class WallpaperService: Service() {
 
 	private fun onFetchError(throwable: Throwable, settings: AppSettings) {
 		val error = when (throwable) {
-			// Wallhaven server bug: certain ratios yield zero results when an API key is present
-			is NoResultsException -> if (settings.apiKey.isNotBlank()) {
+			// The hint only makes sense for Wallhaven: it's the Wallhaven server that yields zero results on certain ratios when an API key is present.
+			is NoResultsException -> if (WallpaperSource.WALLHAVEN in settings.enabledSources && settings.apiKey.isNotBlank()) {
 				AppError.NoResultsWithRatioHint
 			} else {
 				AppError.NoResults

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/settings/SettingsScreen.kt
@@ -77,8 +77,10 @@ import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.POOL_SIZE_OPTIONS
 import xyz.attacktive.wallhavend.domain.model.RotationMode
 import xyz.attacktive.wallhavend.domain.model.UPDATE_INTERVAL_OPTIONS
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.query.Category
+import xyz.attacktive.wallhavend.domain.model.query.LicenseFilter
 import xyz.attacktive.wallhavend.domain.model.query.Purity
 import xyz.attacktive.wallhavend.domain.model.query.Sorting
 import xyz.attacktive.wallhavend.domain.model.query.ToplistRange
@@ -180,17 +182,22 @@ fun SettingsScreen(onNavigateBack: () -> Unit, onNavigateToBlocklist: () -> Unit
 					.fillMaxWidth()
 					.padding(horizontal = 16.dp, vertical = 8.dp)
 			) {
-				Text(
-					text = stringResource(R.string.settings_powered_by),
-					style = MaterialTheme.typography.bodySmall,
-					color = MaterialTheme.colorScheme.onSurfaceVariant,
-					textDecoration = TextDecoration.Underline,
-					textAlign = TextAlign.Center,
-					modifier = Modifier
-						.fillMaxWidth()
-						.clickable { uriHandler.openUri("https://wallhaven.cc") }
-						.padding(vertical = 8.dp)
-				)
+				// Credit only what is actually being searched, and in a fixed order so turning a source on and off doesn't shuffle the footer.
+				settings.enabledSources
+					.sorted()
+					.forEach { source ->
+						Text(
+							text = stringResource(source.attributionRes),
+							style = MaterialTheme.typography.bodySmall,
+							color = MaterialTheme.colorScheme.onSurfaceVariant,
+							textDecoration = TextDecoration.Underline,
+							textAlign = TextAlign.Center,
+							modifier = Modifier
+								.fillMaxWidth()
+								.clickable { uriHandler.openUri(source.homeUrl) }
+								.padding(vertical = 8.dp)
+						)
+					}
 
 				Text(
 					text = stringResource(R.string.settings_report_bug),
@@ -238,6 +245,16 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit, onN
 		onPersist = { onSave(settings.copy(filterColor = it)) }
 	)
 
+	SectionLabel(stringResource(R.string.settings_label_sources))
+
+	MultiSelectChips(
+		entries = WallpaperSource.entries,
+		selected = settings.enabledSources,
+		nameRes = { it.nameRes },
+		onSelectionChange = { onSave(settings.copy(enabledSources = it)) }
+	)
+
+	Spacer(Modifier.height(16.dp))
 	SectionLabel(stringResource(R.string.settings_label_search_query))
 
 	OutlinedTextField(
@@ -249,15 +266,20 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit, onN
 		modifier = Modifier.fillMaxWidth()
 	)
 
-	Spacer(Modifier.height(16.dp))
-	SectionLabel(stringResource(R.string.settings_label_categories))
+	val wallhavenEnabled = WallpaperSource.WALLHAVEN in settings.enabledSources
+	AnimatedVisibility(visible = wallhavenEnabled) {
+		Column {
+			Spacer(Modifier.height(16.dp))
+			SectionLabel(stringResource(R.string.settings_label_categories))
 
-	MultiSelectChips(
-		entries = Category.entries,
-		selected = settings.categories,
-		nameRes = { it.nameRes },
-		onSelectionChange = { onSave(settings.copy(categories = it)) }
-	)
+			MultiSelectChips(
+				entries = Category.entries,
+				selected = settings.categories,
+				nameRes = { it.nameRes },
+				onSelectionChange = { onSave(settings.copy(categories = it)) }
+			)
+		}
+	}
 
 	Spacer(Modifier.height(16.dp))
 	SectionLabel(stringResource(R.string.settings_label_content_rating))
@@ -269,104 +291,152 @@ private fun ContentTab(settings: AppSettings, onSave: (AppSettings) -> Unit, onN
 		onSelectionChange = { onSave(settings.copy(purity = it)) }
 	)
 
-	Spacer(Modifier.height(16.dp))
-	SectionLabel(stringResource(R.string.settings_label_filter_color))
-
-	ColorSwatchPicker(
-		selected = filterColor,
-		onSelect = { newColor ->
-			filterColor = newColor
-			onSave(settings.copy(filterColor = newColor))
-		}
-	)
-
-	OutlinedTextField(
-		value = filterColor,
-		onValueChange = { filterColor = it.replace("#", "").lowercase() },
-		placeholder = { Text(stringResource(R.string.settings_placeholder_filter_color)) },
-		trailingIcon = {
-			if (filterColor.isNotEmpty()) {
-				IconButton(onClick = {
-					filterColor = ""
-					onSave(settings.copy(filterColor = ""))
-				}) {
-					Icon(Icons.Filled.Clear, contentDescription = null)
-				}
-			}
-		},
-		singleLine = true,
-		modifier = Modifier.fillMaxWidth()
-	)
-
-	Text(
-		text = stringResource(R.string.settings_hint_filter_color),
-		style = MaterialTheme.typography.bodySmall,
-		color = MaterialTheme.colorScheme.onSurfaceVariant,
-		modifier = Modifier.padding(top = 4.dp)
-	)
-
-	var sortingExpanded by remember { mutableStateOf(false) }
-
-	Spacer(Modifier.height(16.dp))
-	SectionLabel(stringResource(R.string.settings_label_sorting))
-
-	ExposedDropdownMenuBox(expanded = sortingExpanded, onExpandedChange = { sortingExpanded = it }) {
-		OutlinedTextField(
-			value = stringResource(settings.sorting.nameRes),
-			onValueChange = {},
-			readOnly = true,
-			trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = sortingExpanded) },
-			modifier = Modifier
-				.fillMaxWidth()
-				.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-		)
-
-		ExposedDropdownMenu(expanded = sortingExpanded, onDismissRequest = { sortingExpanded = false }) {
-			Sorting.entries.forEach { option ->
-				DropdownMenuItem(
-					text = { Text(stringResource(option.nameRes)) },
-					onClick = {
-						if (option != settings.sorting) {
-							onSave(settings.copy(sorting = option))
-						}
-
-						sortingExpanded = false
-					}
-				)
-			}
-		}
-	}
-
-	AnimatedVisibility(visible = settings.sorting == Sorting.TOPLIST) {
-		var toplistRangeExpanded by remember { mutableStateOf(false) }
+	val openverseEnabled = WallpaperSource.OPENVERSE in settings.enabledSources
+	AnimatedVisibility(visible = openverseEnabled) {
+		var licenseExpanded by remember { mutableStateOf(false) }
 
 		Column {
 			Spacer(Modifier.height(16.dp))
-			SectionLabel(stringResource(R.string.settings_label_toplist_range))
+			SectionLabel(stringResource(R.string.settings_label_license))
 
-			ExposedDropdownMenuBox(expanded = toplistRangeExpanded, onExpandedChange = { toplistRangeExpanded = it }) {
+			ExposedDropdownMenuBox(expanded = licenseExpanded, onExpandedChange = { licenseExpanded = it }) {
 				OutlinedTextField(
-					value = stringResource(settings.toplistRange.nameRes),
+					value = stringResource(settings.licenseFilter.nameRes),
 					onValueChange = {},
 					readOnly = true,
-					trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = toplistRangeExpanded) },
+					trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = licenseExpanded) },
 					modifier = Modifier
 						.fillMaxWidth()
 						.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
 				)
 
-				ExposedDropdownMenu(expanded = toplistRangeExpanded, onDismissRequest = { toplistRangeExpanded = false }) {
-					ToplistRange.entries.forEach { range ->
+				ExposedDropdownMenu(expanded = licenseExpanded, onDismissRequest = { licenseExpanded = false }) {
+					LicenseFilter.entries.forEach { option ->
 						DropdownMenuItem(
-							text = { Text(stringResource(range.nameRes)) },
+							text = { Text(stringResource(option.nameRes)) },
 							onClick = {
-								if (range != settings.toplistRange) {
-									onSave(settings.copy(toplistRange = range))
+								if (option != settings.licenseFilter) {
+									onSave(settings.copy(licenseFilter = option))
 								}
 
-								toplistRangeExpanded = false
+								licenseExpanded = false
 							}
 						)
+					}
+				}
+			}
+
+			Text(
+				text = stringResource(R.string.settings_hint_license),
+				style = MaterialTheme.typography.bodySmall,
+				color = MaterialTheme.colorScheme.onSurfaceVariant,
+				modifier = Modifier.padding(top = 4.dp)
+			)
+		}
+	}
+
+	AnimatedVisibility(visible = wallhavenEnabled) {
+		var sortingExpanded by remember { mutableStateOf(false) }
+
+		Column {
+			Spacer(Modifier.height(16.dp))
+			SectionLabel(stringResource(R.string.settings_label_filter_color))
+
+			ColorSwatchPicker(
+				selected = filterColor,
+				onSelect = { newColor ->
+					filterColor = newColor
+					onSave(settings.copy(filterColor = newColor))
+				}
+			)
+
+			OutlinedTextField(
+				value = filterColor,
+				onValueChange = { filterColor = it.replace("#", "").lowercase() },
+				placeholder = { Text(stringResource(R.string.settings_placeholder_filter_color)) },
+				trailingIcon = {
+					if (filterColor.isNotEmpty()) {
+						IconButton(onClick = {
+							filterColor = ""
+							onSave(settings.copy(filterColor = ""))
+						}) {
+							Icon(Icons.Filled.Clear, contentDescription = null)
+						}
+					}
+				},
+				singleLine = true,
+				modifier = Modifier.fillMaxWidth()
+			)
+
+			Text(
+				text = stringResource(R.string.settings_hint_filter_color),
+				style = MaterialTheme.typography.bodySmall,
+				color = MaterialTheme.colorScheme.onSurfaceVariant,
+				modifier = Modifier.padding(top = 4.dp)
+			)
+
+			Spacer(Modifier.height(16.dp))
+			SectionLabel(stringResource(R.string.settings_label_sorting))
+
+			ExposedDropdownMenuBox(expanded = sortingExpanded, onExpandedChange = { sortingExpanded = it }) {
+				OutlinedTextField(
+					value = stringResource(settings.sorting.nameRes),
+					onValueChange = {},
+					readOnly = true,
+					trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = sortingExpanded) },
+					modifier = Modifier
+						.fillMaxWidth()
+						.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+				)
+
+				ExposedDropdownMenu(expanded = sortingExpanded, onDismissRequest = { sortingExpanded = false }) {
+					Sorting.entries.forEach { option ->
+						DropdownMenuItem(
+							text = { Text(stringResource(option.nameRes)) },
+							onClick = {
+								if (option != settings.sorting) {
+									onSave(settings.copy(sorting = option))
+								}
+
+								sortingExpanded = false
+							}
+						)
+					}
+				}
+			}
+
+			AnimatedVisibility(visible = settings.sorting == Sorting.TOPLIST) {
+				var toplistRangeExpanded by remember { mutableStateOf(false) }
+
+				Column {
+					Spacer(Modifier.height(16.dp))
+					SectionLabel(stringResource(R.string.settings_label_toplist_range))
+
+					ExposedDropdownMenuBox(expanded = toplistRangeExpanded, onExpandedChange = { toplistRangeExpanded = it }) {
+						OutlinedTextField(
+							value = stringResource(settings.toplistRange.nameRes),
+							onValueChange = {},
+							readOnly = true,
+							trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = toplistRangeExpanded) },
+							modifier = Modifier
+								.fillMaxWidth()
+								.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+						)
+
+						ExposedDropdownMenu(expanded = toplistRangeExpanded, onDismissRequest = { toplistRangeExpanded = false }) {
+							ToplistRange.entries.forEach { range ->
+								DropdownMenuItem(
+									text = { Text(stringResource(range.nameRes)) },
+									onClick = {
+										if (range != settings.toplistRange) {
+											onSave(settings.copy(toplistRange = range))
+										}
+
+										toplistRangeExpanded = false
+									}
+								)
+							}
+						}
 					}
 				}
 			}
@@ -563,17 +633,21 @@ private fun AdvancedTab(settings: AppSettings, onSave: (AppSettings) -> Unit) {
 		}
 	}
 
-	Spacer(Modifier.height(16.dp))
-	SectionLabel(stringResource(R.string.settings_label_api_key))
+	AnimatedVisibility(visible = WallpaperSource.WALLHAVEN in settings.enabledSources) {
+		Column {
+			Spacer(Modifier.height(16.dp))
+			SectionLabel(stringResource(R.string.settings_label_api_key))
 
-	OutlinedTextField(
-		value = apiKey,
-		onValueChange = { apiKey = it },
-		placeholder = { Text(stringResource(R.string.settings_placeholder_api_key)) },
-		visualTransformation = PasswordVisualTransformation(),
-		keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-		modifier = Modifier.fillMaxWidth()
-	)
+			OutlinedTextField(
+				value = apiKey,
+				onValueChange = { apiKey = it },
+				placeholder = { Text(stringResource(R.string.settings_placeholder_api_key)) },
+				visualTransformation = PasswordVisualTransformation(),
+				keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+				modifier = Modifier.fillMaxWidth()
+			)
+		}
+	}
 }
 
 @Composable

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -14,10 +14,13 @@
 	<string name="settings_tab_content">Inhalt</string>
 	<string name="settings_tab_schedule">Zeitplan</string>
 	<string name="settings_tab_advanced">Erweitert</string>
+	<string name="settings_label_sources">QUELLEN</string>
 	<string name="settings_label_search_query">SUCHANFRAGE (OPTIONAL)</string>
 	<string name="settings_placeholder_search_query">z.B. milky way, mountains</string>
 	<string name="settings_label_categories">KATEGORIEN</string>
 	<string name="settings_label_content_rating">CONTENT-RATING</string>
+	<string name="settings_label_license">LIZENZ</string>
+	<string name="settings_hint_license">Openverse indexiert Bilder, die anderswo liegen; dies begrenzt die akzeptierten Lizenzen</string>
 	<string name="settings_label_filter_color">FARBFILTER (OPTIONAL)</string>
 	<string name="settings_hint_filter_color">Leer lassen, um das Filtern nach Farbe zu überspringen</string>
 	<string name="settings_placeholder_filter_color">z.B. ff0000 oder ff0000,0066cc</string>
@@ -57,7 +60,8 @@
 	<string name="settings_subtitle_pool_size">Hintergrundbilder, die auf dem Gerät behalten und in der Galerie angezeigt werden (ohne angeheftete)</string>
 	<string name="settings_label_api_key">API-KEY (OPTIONAL, FÜR NSFW ERFORDERLICH)</string>
 	<string name="settings_placeholder_api_key">Dein Wallhaven API-Key</string>
-	<string name="settings_powered_by">Unterstützt von wallhaven.cc</string>
+	<string name="settings_powered_by_wallhaven">Unterstützt von wallhaven.cc</string>
+	<string name="settings_powered_by_openverse">Erstellt mit Openverse — nicht von Openverse unterstützt oder zertifiziert</string>
 	<string name="settings_report_bug">Einen Fehler melden</string>
 	<string name="category_general">Allgemein</string>
 	<string name="category_anime">Anime</string>
@@ -65,6 +69,11 @@
 	<string name="purity_sfw">SFW</string>
 	<string name="purity_sketchy">Sketchy</string>
 	<string name="purity_nsfw">NSFW</string>
+	<string name="source_wallhaven">Wallhaven</string>
+	<string name="source_openverse">Openverse</string>
+	<string name="license_public_domain">Gemeinfrei</string>
+	<string name="license_permissive">Freizügig</string>
+	<string name="license_any_commercial">Jede kommerzielle Nutzung</string>
 	<string name="error_no_results">⚠ Keine Ergebnisse — versuchen Sie, Ihre Filter zu lockern</string>
 	<string name="error_no_results_hint">⚠ Keine Ergebnisse — versuchen Sie, Ihre Filter zu lockern oder den API-Key zu entfernen, wenn Sie keine NSFW-Hintergründe benötigen</string>
 	<string name="error_api_error">⚠ API-Fehler %d</string>
@@ -89,7 +98,7 @@
 	<string name="blocklist_empty">Noch nichts blockiert. Blockiere ein Hintergrundbild in der Vorschau, um es aus zukünftigen Rotationen auszublenden.</string>
 	<string name="blocklist_unblock">Freigeben</string>
 	<string name="blocklist_reveal">Vorschaubild anzeigen</string>
-	<string name="blocklist_open_hint">Auf ID tippen, um es auf wallhaven.cc anzusehen</string>
+	<string name="blocklist_open_hint">Auf ID tippen, um ihre Seite anzusehen</string>
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 Std.</string>
 	<string name="settings_unit_hr_plural">%d Std.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -14,10 +14,13 @@
 	<string name="settings_tab_content">Contenido</string>
 	<string name="settings_tab_schedule">Programación</string>
 	<string name="settings_tab_advanced">Avanzado</string>
+	<string name="settings_label_sources">FUENTES</string>
 	<string name="settings_label_search_query">CONSULTA DE BÚSQUEDA (OPCIONAL)</string>
 	<string name="settings_placeholder_search_query">ej. milky way, mountains</string>
 	<string name="settings_label_categories">CATEGORÍAS</string>
 	<string name="settings_label_content_rating">CLASIFICACIÓN DE CONTENIDO</string>
+	<string name="settings_label_license">LICENCIA</string>
+	<string name="settings_hint_license">Openverse indexa imágenes alojadas en otros sitios; esto limita las licencias aceptadas</string>
 	<string name="settings_label_filter_color">FILTRO DE COLOR (OPCIONAL)</string>
 	<string name="settings_hint_filter_color">Dejar en blanco para omitir el filtrado por color</string>
 	<string name="settings_placeholder_filter_color">ej. ff0000 o ff0000,0066cc</string>
@@ -57,7 +60,8 @@
 	<string name="settings_subtitle_pool_size">Fondos de pantalla guardados en el dispositivo y mostrados en la galería (excluyendo fijados)</string>
 	<string name="settings_label_api_key">CLAVE API (OPCIONAL, REQUERIDA PARA NSFW)</string>
 	<string name="settings_placeholder_api_key">Tu clave API de Wallhaven</string>
-	<string name="settings_powered_by">Desarrollado por wallhaven.cc</string>
+	<string name="settings_powered_by_wallhaven">Desarrollado por wallhaven.cc</string>
+	<string name="settings_powered_by_openverse">Creado con Openverse — sin respaldo ni certificación de Openverse</string>
 	<string name="settings_report_bug">Informar de un error</string>
 	<string name="category_general">General</string>
 	<string name="category_anime">Anime</string>
@@ -65,6 +69,11 @@
 	<string name="purity_sfw">SFW</string>
 	<string name="purity_sketchy">Sketchy</string>
 	<string name="purity_nsfw">NSFW</string>
+	<string name="source_wallhaven">Wallhaven</string>
+	<string name="source_openverse">Openverse</string>
+	<string name="license_public_domain">Dominio público</string>
+	<string name="license_permissive">Permisiva</string>
+	<string name="license_any_commercial">Cualquier uso comercial</string>
 	<string name="error_no_results">⚠ Sin resultados — intenta relajar tus filtros</string>
 	<string name="error_no_results_hint">⚠ Sin resultados — intenta relajar tus filtros o quita la clave API si no necesitas fondos NSFW</string>
 	<string name="error_api_error">⚠ Error de API %d</string>
@@ -89,7 +98,7 @@
 	<string name="blocklist_empty">Nada bloqueado todavía. Bloquea un fondo desde su vista previa para ocultarlo de futuras rotaciones.</string>
 	<string name="blocklist_unblock">Desbloquear</string>
 	<string name="blocklist_reveal">Mostrar miniatura</string>
-	<string name="blocklist_open_hint">Toca el ID para verlo en wallhaven.cc</string>
+	<string name="blocklist_open_hint">Toca el ID para ver su página</string>
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 h</string>
 	<string name="settings_unit_hr_plural">%d h</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -14,10 +14,13 @@
 	<string name="settings_tab_content">Contenu</string>
 	<string name="settings_tab_schedule">Plannification</string>
 	<string name="settings_tab_advanced">Avancé</string>
+	<string name="settings_label_sources">SOURCES</string>
 	<string name="settings_label_search_query">RECHERCHE (OPTIONNEL)</string>
 	<string name="settings_placeholder_search_query">ex: milky way, mountains</string>
 	<string name="settings_label_categories">CATÉGORIES</string>
 	<string name="settings_label_content_rating">CLASSEMENT DU CONTENU</string>
+	<string name="settings_label_license">LICENCE</string>
+	<string name="settings_hint_license">Openverse référence des images hébergées ailleurs ; ceci limite les licences acceptées</string>
 	<string name="settings_label_filter_color">FILTRE COULEUR (OPTIONNEL)</string>
 	<string name="settings_hint_filter_color">Laisser vide pour ignorer le filtre couleur</string>
 	<string name="settings_placeholder_filter_color">ex: ff0000 ou ff0000,0066cc</string>
@@ -57,7 +60,8 @@
 	<string name="settings_subtitle_pool_size">Fonds d\'écran gardés sur l\'appareil et affichés dans la galerie (hors épinglés)</string>
 	<string name="settings_label_api_key">CLÉ API (OPTIONNEL, REQUIS POUR NSFW)</string>
 	<string name="settings_placeholder_api_key">Votre clé API Wallhaven</string>
-	<string name="settings_powered_by">Propulsé par wallhaven.cc</string>
+	<string name="settings_powered_by_wallhaven">Propulsé par wallhaven.cc</string>
+	<string name="settings_powered_by_openverse">Réalisé avec Openverse — sans approbation ni certification d\'Openverse</string>
 	<string name="settings_report_bug">Signaler un bug</string>
 	<string name="category_general">Général</string>
 	<string name="category_anime">Anime</string>
@@ -65,6 +69,11 @@
 	<string name="purity_sfw">SFW</string>
 	<string name="purity_sketchy">Sketchy</string>
 	<string name="purity_nsfw">NSFW</string>
+	<string name="source_wallhaven">Wallhaven</string>
+	<string name="source_openverse">Openverse</string>
+	<string name="license_public_domain">Domaine public</string>
+	<string name="license_permissive">Permissive</string>
+	<string name="license_any_commercial">Tout usage commercial</string>
 	<string name="error_no_results">⚠ Aucun résultat — essayez de relâcher vos filtres</string>
 	<string name="error_no_results_hint">⚠ Aucun résultat — essayez de relâcher vos filtres ou d\'enlever la clé API si vous n\'avez pas besoin de fonds NSFW</string>
 	<string name="error_api_error">⚠ Erreur API %d</string>
@@ -89,7 +98,7 @@
 	<string name="blocklist_empty">Rien de bloqué pour l\'instant. Bloquez un fond d\'écran depuis son aperçu pour le masquer des prochaines rotations.</string>
 	<string name="blocklist_unblock">Débloquer</string>
 	<string name="blocklist_reveal">Afficher la miniature</string>
-	<string name="blocklist_open_hint">Appuyez sur l\'ID pour le voir sur wallhaven.cc</string>
+	<string name="blocklist_open_hint">Appuyez sur l\'ID pour voir sa page</string>
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 h</string>
 	<string name="settings_unit_hr_plural">%d h</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -14,10 +14,13 @@
 	<string name="settings_tab_content">コンテンツ</string>
 	<string name="settings_tab_schedule">スケジュール</string>
 	<string name="settings_tab_advanced">詳細</string>
+	<string name="settings_label_sources">ソース</string>
 	<string name="settings_label_search_query">検索クエリ (任意)</string>
 	<string name="settings_placeholder_search_query">例: milky way, mountains</string>
 	<string name="settings_label_categories">カテゴリ</string>
 	<string name="settings_label_content_rating">コンテンツ評価</string>
+	<string name="settings_label_license">ライセンス</string>
+	<string name="settings_hint_license">Openverse は他サイトにある画像を検索します。ここで許可するライセンスを絞り込めます</string>
 	<string name="settings_label_filter_color">カラーフィルター (任意)</string>
 	<string name="settings_hint_filter_color">カラーフィルタリングをスキップするには空欄にします</string>
 	<string name="settings_placeholder_filter_color">例: ff0000 または ff0000,0066cc</string>
@@ -57,7 +60,8 @@
 	<string name="settings_subtitle_pool_size">デバイスに保存され、ギャラリーに表示される壁紙の数（ピン留めを除く）</string>
 	<string name="settings_label_api_key">APIキー (任意、NSFWに必要)</string>
 	<string name="settings_placeholder_api_key">Wallhaven APIキー</string>
-	<string name="settings_powered_by">Powered by wallhaven.cc</string>
+	<string name="settings_powered_by_wallhaven">Powered by wallhaven.cc</string>
+	<string name="settings_powered_by_openverse">Openverse を利用 — Openverse による承認・認定は受けていません</string>
 	<string name="settings_report_bug">バグを報告</string>
 	<string name="category_general">一般</string>
 	<string name="category_anime">アニメ</string>
@@ -65,6 +69,11 @@
 	<string name="purity_sfw">SFW</string>
 	<string name="purity_sketchy">Sketchy</string>
 	<string name="purity_nsfw">NSFW</string>
+	<string name="source_wallhaven">Wallhaven</string>
+	<string name="source_openverse">Openverse</string>
+	<string name="license_public_domain">パブリックドメイン</string>
+	<string name="license_permissive">寛容なライセンス</string>
+	<string name="license_any_commercial">商用利用可</string>
 	<string name="error_no_results">⚠ 結果がありません — フィルターを緩めてみてください</string>
 	<string name="error_no_results_hint">⚠ 結果がありません — フィルターを緩めるか、NSFW壁紙が不要な場合はAPIキーを削除してみてください</string>
 	<string name="error_api_error">⚠ APIエラー %d</string>
@@ -89,7 +98,7 @@
 	<string name="blocklist_empty">まだ何もブロックしていません。プレビューから壁紙をブロックすると、今後のローテーションから除外されます。</string>
 	<string name="blocklist_unblock">ブロック解除</string>
 	<string name="blocklist_reveal">サムネイルを表示</string>
-	<string name="blocklist_open_hint">IDをタップして wallhaven.cc で表示</string>
+	<string name="blocklist_open_hint">IDをタップしてそのページを表示</string>
 	<string name="settings_unit_min">%d分</string>
 	<string name="settings_unit_hr_single">1時間</string>
 	<string name="settings_unit_hr_plural">%d時間</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -14,10 +14,13 @@
 	<string name="settings_tab_content">콘텐츠</string>
 	<string name="settings_tab_schedule">일정</string>
 	<string name="settings_tab_advanced">고급</string>
+	<string name="settings_label_sources">소스</string>
 	<string name="settings_label_search_query">검색어 (선택 사항)</string>
 	<string name="settings_placeholder_search_query">예: milky way, mountains</string>
 	<string name="settings_label_categories">카테고리</string>
 	<string name="settings_label_content_rating">콘텐츠 등급</string>
+	<string name="settings_label_license">라이선스</string>
+	<string name="settings_hint_license">Openverse는 다른 사이트에 있는 이미지를 검색합니다. 허용할 라이선스를 제한합니다</string>
 	<string name="settings_label_filter_color">색상 필터 (선택 사항)</string>
 	<string name="settings_hint_filter_color">색상 필터링을 건너뛰려면 비워 두세요</string>
 	<string name="settings_placeholder_filter_color">예: ff0000 또는 ff0000,0066cc</string>
@@ -57,7 +60,8 @@
 	<string name="settings_subtitle_pool_size">기기에 보관되고 갤러리에 표시되는 배경화면 수 (고정된 항목 제외)</string>
 	<string name="settings_label_api_key">API 키 (선택 사항, NSFW 필수)</string>
 	<string name="settings_placeholder_api_key">Wallhaven API 키</string>
-	<string name="settings_powered_by">Powered by wallhaven.cc</string>
+	<string name="settings_powered_by_wallhaven">Powered by wallhaven.cc</string>
+	<string name="settings_powered_by_openverse">Openverse 사용 — Openverse의 보증이나 인증을 받지 않았습니다</string>
 	<string name="settings_report_bug">버그 보고</string>
 	<string name="category_general">일반</string>
 	<string name="category_anime">애니메이션</string>
@@ -65,6 +69,11 @@
 	<string name="purity_sfw">SFW</string>
 	<string name="purity_sketchy">Sketchy</string>
 	<string name="purity_nsfw">NSFW</string>
+	<string name="source_wallhaven">Wallhaven</string>
+	<string name="source_openverse">Openverse</string>
+	<string name="license_public_domain">퍼블릭 도메인</string>
+	<string name="license_permissive">관대한 라이선스</string>
+	<string name="license_any_commercial">상업적 이용 가능</string>
 	<string name="error_no_results">⚠ 결과가 없습니다 — 필터를 완화해 보세요</string>
 	<string name="error_no_results_hint">⚠ 결과가 없습니다 — 필터를 완화하거나, NSFW 배경화면이 필요하지 않은 경우 API 키를 제거해 보세요</string>
 	<string name="error_api_error">⚠ API 오류 %d</string>
@@ -89,7 +98,7 @@
 	<string name="blocklist_empty">아직 차단한 항목이 없습니다. 미리보기에서 배경화면을 차단하면 이후 순환에서 숨겨집니다.</string>
 	<string name="blocklist_unblock">차단 해제</string>
 	<string name="blocklist_reveal">썸네일 표시</string>
-	<string name="blocklist_open_hint">ID를 탭하여 wallhaven.cc에서 보기</string>
+	<string name="blocklist_open_hint">ID를 탭하여 해당 페이지 보기</string>
 	<string name="settings_unit_min">%d분</string>
 	<string name="settings_unit_hr_single">1시간</string>
 	<string name="settings_unit_hr_plural">%d시간</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -14,10 +14,13 @@
 	<string name="settings_tab_content">Conteúdo</string>
 	<string name="settings_tab_schedule">Agendamento</string>
 	<string name="settings_tab_advanced">Avançado</string>
+	<string name="settings_label_sources">FONTES</string>
 	<string name="settings_label_search_query">TERMO DE BUSCA (OPCIONAL)</string>
 	<string name="settings_placeholder_search_query">ex: milky way, mountains</string>
 	<string name="settings_label_categories">CATEGORIAS</string>
 	<string name="settings_label_content_rating">CLASSIFICAÇÃO DE CONTEÚDO</string>
+	<string name="settings_label_license">LICENÇA</string>
+	<string name="settings_hint_license">O Openverse indexa imagens hospedadas em outros sites; isto limita as licenças aceitas</string>
 	<string name="settings_label_filter_color">FILTRO DE COR (OPCIONAL)</string>
 	<string name="settings_hint_filter_color">Deixe em branco para ignorar a filtragem por cor</string>
 	<string name="settings_placeholder_filter_color">ex: ff0000 ou ff0000,0066cc</string>
@@ -57,7 +60,8 @@
 	<string name="settings_subtitle_pool_size">Papéis de parede mantidos no dispositivo e exibidos na galeria (excluindo fixados)</string>
 	<string name="settings_label_api_key">CHAVE API (OPCIONAL, NECESSÁRIA PARA NSFW)</string>
 	<string name="settings_placeholder_api_key">Sua chave API do Wallhaven</string>
-	<string name="settings_powered_by">Distribuído por wallhaven.cc</string>
+	<string name="settings_powered_by_wallhaven">Distribuído por wallhaven.cc</string>
+	<string name="settings_powered_by_openverse">Feito com o Openverse — sem endosso ou certificação do Openverse</string>
 	<string name="settings_report_bug">Relatar um erro</string>
 	<string name="category_general">Geral</string>
 	<string name="category_anime">Anime</string>
@@ -65,6 +69,11 @@
 	<string name="purity_sfw">SFW</string>
 	<string name="purity_sketchy">Sketchy</string>
 	<string name="purity_nsfw">NSFW</string>
+	<string name="source_wallhaven">Wallhaven</string>
+	<string name="source_openverse">Openverse</string>
+	<string name="license_public_domain">Domínio público</string>
+	<string name="license_permissive">Permissiva</string>
+	<string name="license_any_commercial">Qualquer uso comercial</string>
 	<string name="error_no_results">⚠ Sem resultados — tente relaxar seus filtros</string>
 	<string name="error_no_results_hint">⚠ Sem resultados — tente relaxar seus filtros ou remova a chave API se não precisar de papéis de parede NSFW</string>
 	<string name="error_api_error">⚠ Erro de API %d</string>
@@ -89,7 +98,7 @@
 	<string name="blocklist_empty">Nada bloqueado ainda. Bloqueie um papel de parede na visualização para ocultá-lo de rotações futuras.</string>
 	<string name="blocklist_unblock">Desbloquear</string>
 	<string name="blocklist_reveal">Mostrar miniatura</string>
-	<string name="blocklist_open_hint">Toque no ID para ver em wallhaven.cc</string>
+	<string name="blocklist_open_hint">Toque no ID para ver sua página</string>
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 h</string>
 	<string name="settings_unit_hr_plural">%d h</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -14,10 +14,13 @@
 	<string name="settings_tab_content">内容</string>
 	<string name="settings_tab_schedule">计划</string>
 	<string name="settings_tab_advanced">高级</string>
+	<string name="settings_label_sources">来源</string>
 	<string name="settings_label_search_query">搜索内容 (可选)</string>
 	<string name="settings_placeholder_search_query">例如：milky way, mountains</string>
 	<string name="settings_label_categories">分类</string>
 	<string name="settings_label_content_rating">内容分级</string>
+	<string name="settings_label_license">许可协议</string>
+	<string name="settings_hint_license">Openverse 索引的图片托管在其他站点；此项限制可接受的许可协议</string>
 	<string name="settings_label_filter_color">颜色筛选（可选）</string>
 	<string name="settings_hint_filter_color">留空以跳过颜色筛选</string>
 	<string name="settings_placeholder_filter_color">例如：ff0000 或 ff0000,0066cc</string>
@@ -57,7 +60,8 @@
 	<string name="settings_subtitle_pool_size">在设备上保留并在图库中显示的壁纸数量（不含已置顶）</string>
 	<string name="settings_label_api_key">API 密钥 (可选，访问 NSFW 内容必填)</string>
 	<string name="settings_placeholder_api_key">您的 Wallhaven API 密钥</string>
-	<string name="settings_powered_by">由 wallhaven.cc 提供支持</string>
+	<string name="settings_powered_by_wallhaven">由 wallhaven.cc 提供支持</string>
+	<string name="settings_powered_by_openverse">使用 Openverse 构建 — 未获 Openverse 认可或认证</string>
 	<string name="settings_report_bug">反馈问题</string>
 	<string name="category_general">常规</string>
 	<string name="category_anime">动漫</string>
@@ -65,6 +69,11 @@
 	<string name="purity_sfw">SFW (安全)</string>
 	<string name="purity_sketchy">Sketchy (较敏感)</string>
 	<string name="purity_nsfw">NSFW (成人)</string>
+	<string name="source_wallhaven">Wallhaven</string>
+	<string name="source_openverse">Openverse</string>
+	<string name="license_public_domain">公有领域</string>
+	<string name="license_permissive">宽松许可</string>
+	<string name="license_any_commercial">允许商业使用</string>
 	<string name="error_no_results">⚠ 无结果 — 请尝试放宽过滤条件</string>
 	<string name="error_no_results_hint">⚠ 无结果 — 请尝试放宽过滤条件，或在不需要 NSFW 壁纸时移除 API 密钥</string>
 	<string name="error_api_error">⚠ API 错误 %d</string>
@@ -89,7 +98,7 @@
 	<string name="blocklist_empty">尚未屏蔽任何内容。在预览中屏蔽壁纸，即可在后续轮换中将其隐藏。</string>
 	<string name="blocklist_unblock">取消屏蔽</string>
 	<string name="blocklist_reveal">显示缩略图</string>
-	<string name="blocklist_open_hint">点按 ID 在 wallhaven.cc 上查看</string>
+	<string name="blocklist_open_hint">点按 ID 打开对应页面</string>
 	<string name="settings_unit_min">%d 分钟</string>
 	<string name="settings_unit_hr_single">1 小时</string>
 	<string name="settings_unit_hr_plural">%d 小时</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,10 +14,13 @@
 	<string name="settings_tab_content">Content</string>
 	<string name="settings_tab_schedule">Schedule</string>
 	<string name="settings_tab_advanced">Advanced</string>
+	<string name="settings_label_sources">SOURCES</string>
 	<string name="settings_label_search_query">SEARCH QUERY (OPTIONAL)</string>
 	<string name="settings_placeholder_search_query">e.g. milky way, mountains</string>
 	<string name="settings_label_categories">CATEGORIES</string>
 	<string name="settings_label_content_rating">CONTENT RATING</string>
+	<string name="settings_label_license">LICENSE</string>
+	<string name="settings_hint_license">Openverse indexes images hosted elsewhere; this limits which licenses are accepted</string>
 	<string name="settings_label_filter_color">COLOR FILTER (OPTIONAL)</string>
 	<string name="settings_hint_filter_color">Leave blank to skip color filtering</string>
 	<string name="settings_placeholder_filter_color">e.g. ff0000 or ff0000,0066cc</string>
@@ -57,7 +60,8 @@
 	<string name="settings_subtitle_pool_size">Wallpapers kept on device and shown in gallery (excludes pinned)</string>
 	<string name="settings_label_api_key">API KEY (OPTIONAL, REQUIRED FOR NSFW)</string>
 	<string name="settings_placeholder_api_key">Your Wallhaven API key</string>
-	<string name="settings_powered_by">Powered by wallhaven.cc</string>
+	<string name="settings_powered_by_wallhaven">Powered by wallhaven.cc</string>
+	<string name="settings_powered_by_openverse">Made using Openverse — not endorsed or certified by Openverse</string>
 	<string name="settings_report_bug">Report a bug</string>
 	<string name="category_general">General</string>
 	<string name="category_anime">Anime</string>
@@ -65,6 +69,11 @@
 	<string name="purity_sfw">SFW</string>
 	<string name="purity_sketchy">Sketchy</string>
 	<string name="purity_nsfw">NSFW</string>
+	<string name="source_wallhaven">Wallhaven</string>
+	<string name="source_openverse">Openverse</string>
+	<string name="license_public_domain">Public domain</string>
+	<string name="license_permissive">Permissive</string>
+	<string name="license_any_commercial">Any commercial use</string>
 	<string name="error_no_results">⚠ No results — try relaxing your filters</string>
 	<string name="error_no_results_hint">⚠ No results — try relaxing your filters, or remove the API key if you don\'t need NSFW wallpapers</string>
 	<string name="error_api_error">⚠ API error %d</string>
@@ -89,7 +98,7 @@
 	<string name="blocklist_empty">Nothing blocked yet. Block a wallpaper from its preview to hide it from future rotations.</string>
 	<string name="blocklist_unblock">Unblock</string>
 	<string name="blocklist_reveal">Reveal thumbnail</string>
-	<string name="blocklist_open_hint">Tap ID to view on wallhaven.cc</string>
+	<string name="blocklist_open_hint">Tap an ID to view its page</string>
 	<string name="settings_unit_min">%d min</string>
 	<string name="settings_unit_hr_single">1 hr</string>
 	<string name="settings_unit_hr_plural">%d hr</string>

--- a/app/src/test/java/xyz/attacktive/wallhavend/OpenverseProviderTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/OpenverseProviderTest.kt
@@ -1,0 +1,285 @@
+package xyz.attacktive.wallhavend
+
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import xyz.attacktive.wallhavend.data.api.OpenverseApiService
+import xyz.attacktive.wallhavend.data.api.dto.OpenverseImageDto
+import xyz.attacktive.wallhavend.data.api.dto.OpenverseSearchResponseDto
+import xyz.attacktive.wallhavend.domain.model.AppSettings
+import xyz.attacktive.wallhavend.domain.model.NoResultsException
+import xyz.attacktive.wallhavend.domain.model.ScreenInfo
+import xyz.attacktive.wallhavend.domain.model.WallpaperSource
+import xyz.attacktive.wallhavend.domain.model.query.LicenseFilter
+import xyz.attacktive.wallhavend.domain.model.query.Purity
+import xyz.attacktive.wallhavend.domain.repository.OpenverseProvider
+
+class OpenverseProviderTest {
+	private val openverseApiService = mockk<OpenverseApiService>()
+	private lateinit var provider: OpenverseProvider
+
+	private val portraitScreen = ScreenInfo("9x16", 1080, 2400)
+	private val landscapeScreen = ScreenInfo("16x9", 2400, 1080)
+	private val squareScreen = ScreenInfo("1x1", 1440, 1440)
+
+	/** Comfortably larger than any screen here, so a result only ever gets dropped when a test means it to. */
+	private fun makeImage(id: String, url: String? = "https://cdn/$id.jpg", width: Int? = 4000, height: Int? = 4000) = OpenverseImageDto(
+		id = id,
+		url = url,
+		width = width,
+		height = height
+	)
+
+	private fun makePage(vararg images: OpenverseImageDto, pageCount: Int = 1, page: Int = 1) = OpenverseSearchResponseDto(pageCount = pageCount, page = page, results = images.toList())
+
+	private fun everySearch() = coEvery {
+		openverseApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any())
+	}
+
+	@Before
+	fun setUp() {
+		provider = OpenverseProvider(openverseApiService)
+	}
+
+	@Test
+	fun `next returns a result qualified as an Openverse wallpaper`() = runTest {
+		everySearch() returns makePage(makeImage("abc-123"))
+
+		val result = provider.next(AppSettings(), portraitScreen, emptySet())
+
+		assertTrue(result.isSuccess)
+		assertEquals(WallpaperSource.OPENVERSE, result.getOrNull()?.identity?.source)
+		assertEquals("abc-123", result.getOrNull()?.identity?.id)
+		assertEquals("https://cdn/abc-123.jpg", result.getOrNull()?.directUrl)
+	}
+
+	@Test
+	fun `an empty result set gives up without another page`() = runTest {
+		everySearch() returns makePage()
+
+		val result = provider.next(AppSettings(), portraitScreen, emptySet())
+
+		assertTrue(result.exceptionOrNull() is NoResultsException)
+		coVerify(exactly = 1) { openverseApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `a failing search surfaces its own error`() = runTest {
+		everySearch() throws IOException("search is down")
+
+		val result = provider.next(AppSettings(), portraitScreen, emptySet())
+
+		assertTrue(result.exceptionOrNull() is IOException)
+	}
+
+	@Test
+	fun `a blocked wallpaper is skipped`() = runTest {
+		everySearch() returns makePage(makeImage("blocked"), makeImage("free"))
+
+		val result = provider.next(AppSettings(), portraitScreen, setOf("blocked"))
+
+		assertEquals("free", result.getOrNull()?.identity?.id)
+	}
+
+	@Test
+	fun `a second wallpaper comes out of the cache rather than another search`() = runTest {
+		everySearch() returns makePage(makeImage("w1"), makeImage("w2"))
+
+		provider.next(AppSettings(), portraitScreen, emptySet())
+		provider.next(AppSettings(), portraitScreen, emptySet())
+
+		coVerify(exactly = 1) { openverseApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `changing a setting throws the cache away`() = runTest {
+		everySearch() returns makePage(makeImage("w1"), makeImage("w2"))
+
+		provider.next(AppSettings(), portraitScreen, emptySet())
+		provider.next(AppSettings(licenseFilter = LicenseFilter.PERMISSIVE), portraitScreen, emptySet())
+
+		coVerify(exactly = 2) { openverseApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `each keyword gets its own search`() = runTest {
+		everySearch() returns makePage(makeImage("w1"))
+
+		provider.next(AppSettings(searchQuery = "mountains, rivers"), portraitScreen, emptySet())
+
+		coVerify(exactly = 1) { openverseApiService.search("mountains", any(), any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = 1) { openverseApiService.search("rivers", any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `an empty query searches once with no keyword`() = runTest {
+		everySearch() returns makePage(makeImage("w1"))
+
+		provider.next(AppSettings(), portraitScreen, emptySet())
+
+		coVerify(exactly = 1) { openverseApiService.search(null, any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `the licence tier reaches the query`() = runTest {
+		everySearch() returns makePage(makeImage("w1"))
+
+		provider.next(AppSettings(licenseFilter = LicenseFilter.ANY_COMMERCIAL), portraitScreen, emptySet())
+
+		coVerify { openverseApiService.search(any(), "cc0,pdm,by,by-sa,by-nd", any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `the licence defaults to the tier that carries no obligations`() = runTest {
+		everySearch() returns makePage(makeImage("w1"))
+
+		provider.next(AppSettings(), portraitScreen, emptySet())
+
+		coVerify { openverseApiService.search(any(), "cc0,pdm", any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `the screen's shape picks one of the three ratios Openverse knows`() = runTest {
+		everySearch() returns makePage(makeImage("w1"))
+
+		provider.next(AppSettings(), portraitScreen, emptySet())
+		provider.next(AppSettings(), landscapeScreen, emptySet())
+		provider.next(AppSettings(), squareScreen, emptySet())
+
+		coVerify(exactly = 1) { openverseApiService.search(any(), any(), any(), any(), "tall", any(), any(), any(), any()) }
+		coVerify(exactly = 1) { openverseApiService.search(any(), any(), any(), any(), "wide", any(), any(), any(), any()) }
+		coVerify(exactly = 1) { openverseApiService.search(any(), any(), any(), any(), "square", any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `only NSFW asks Openverse to widen to mature results`() = runTest {
+		everySearch() returns makePage(makeImage("w1"))
+
+		provider.next(AppSettings(purity = setOf(Purity.SFW, Purity.SKETCHY)), portraitScreen, emptySet())
+		provider.next(AppSettings(purity = setOf(Purity.SFW, Purity.NSFW)), portraitScreen, emptySet())
+
+		coVerify(exactly = 1) { openverseApiService.search(any(), any(), any(), any(), any(), any(), false, any(), any()) }
+		coVerify(exactly = 1) { openverseApiService.search(any(), any(), any(), any(), any(), any(), true, any(), any()) }
+	}
+
+	@Test
+	fun `only JPEG and PNG are asked for, and only from the curated sources`() = runTest {
+		everySearch() returns makePage(makeImage("w1"))
+
+		provider.next(AppSettings(), portraitScreen, emptySet())
+
+		coVerify { openverseApiService.search(any(), any(), "flickr,wikimedia,nasa,spacex,rawpixel,stocksnap", "jpg,png", any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `avoiding blurry wallpapers asks for large ones and drops the ones that are too small anyway`() = runTest {
+		everySearch() returns makePage(makeImage("small", width = 800, height = 600), makeImage("big"))
+
+		val result = provider.next(AppSettings(avoidBlurryWallpapers = true), portraitScreen, emptySet())
+
+		assertEquals("big", result.getOrNull()?.identity?.id)
+		coVerify { openverseApiService.search(any(), any(), any(), any(), any(), "large", any(), any(), any()) }
+	}
+
+	@Test
+	fun `a result that never reported its size is dropped only when the size matters`() = runTest {
+		val sizeless = makeImage("sizeless", width = null, height = null)
+		everySearch() returns makePage(sizeless, makeImage("sized"))
+
+		assertEquals("sized", provider.next(AppSettings(avoidBlurryWallpapers = true), portraitScreen, emptySet()).getOrNull()?.identity?.id)
+
+		everySearch() returns makePage(sizeless)
+
+		assertTrue(provider.next(AppSettings(), portraitScreen, emptySet()).isSuccess)
+	}
+
+	@Test
+	fun `a result without a direct url is skipped for one that has one`() = runTest {
+		everySearch() returns makePage(makeImage("url-less", url = null), makeImage("linked"))
+
+		val result = provider.next(AppSettings(), portraitScreen, emptySet())
+
+		assertEquals("linked", result.getOrNull()?.identity?.id)
+	}
+
+	@Test
+	fun `a page of only url-less results gives up after the bounded refetch`() = runTest {
+		everySearch() returns makePage(makeImage("url-less", url = null))
+
+		val result = provider.next(AppSettings(), portraitScreen, emptySet())
+
+		assertTrue(result.exceptionOrNull() is NoResultsException)
+		coVerify(exactly = 5) { openverseApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `a page that filters down to nothing earns another page rather than a no-results`() = runTest {
+		val tooSmall = makePage(makeImage("small", width = 800, height = 600))
+		everySearch() returnsMany listOf(tooSmall, makePage(makeImage("big")))
+
+		val result = provider.next(AppSettings(avoidBlurryWallpapers = true), portraitScreen, emptySet())
+
+		assertEquals("big", result.getOrNull()?.identity?.id)
+		coVerify(exactly = 2) { openverseApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `a search that never yields anything usable gives up instead of paging forever`() = runTest {
+		everySearch() returns makePage(makeImage("small", width = 800, height = 600))
+
+		val result = provider.next(AppSettings(avoidBlurryWallpapers = true), portraitScreen, emptySet())
+
+		assertTrue(result.exceptionOrNull() is NoResultsException)
+		coVerify(exactly = 5) { openverseApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `the first page is page one and every later one stays inside the anonymous depth cap`() = runTest {
+		val requestedPages = mutableListOf<Int>()
+		coEvery {
+			openverseApiService.search(any(), any(), any(), any(), any(), any(), any(), capture(requestedPages), any())
+		} returns makePage(makeImage("w1"), pageCount = 500)
+
+		repeat(30) { provider.next(AppSettings(), portraitScreen, emptySet()) }
+
+		assertEquals(30, requestedPages.size)
+		assertEquals(1, requestedPages.first())
+		assertTrue(requestedPages.all { it in 1..12 })
+		assertFalse("a random page should not keep landing on the first one", requestedPages.all { it == 1 })
+	}
+
+	@Test
+	fun `a page count below the depth cap is what bounds the paging`() = runTest {
+		val requestedPages = mutableListOf<Int>()
+		coEvery {
+			openverseApiService.search(any(), any(), any(), any(), any(), any(), any(), capture(requestedPages), any())
+		} returns makePage(makeImage("w1"), pageCount = 3)
+
+		repeat(20) { provider.next(AppSettings(), portraitScreen, emptySet()) }
+
+		assertTrue(requestedPages.all { it in 1..3 })
+	}
+
+	@Test
+	fun `the narrowest keyword decides how deep the shared page number may go`() = runTest {
+		val requestedPages = mutableListOf<Int>()
+		coEvery {
+			openverseApiService.search("wide", any(), any(), any(), any(), any(), any(), any(), any())
+		} returns makePage(makeImage("w1"), pageCount = 500)
+
+		coEvery {
+			openverseApiService.search("narrow", any(), any(), any(), any(), any(), any(), capture(requestedPages), any())
+		} returns makePage(makeImage("n1"), pageCount = 2)
+
+		repeat(20) { provider.next(AppSettings(searchQuery = "wide, narrow"), portraitScreen, emptySet()) }
+
+		assertTrue(requestedPages.all { it in 1..2 })
+	}
+}

--- a/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/SettingsRepositoryTest.kt
@@ -25,6 +25,7 @@ import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
 import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.query.Category
+import xyz.attacktive.wallhavend.domain.model.query.LicenseFilter
 import xyz.attacktive.wallhavend.domain.model.query.Purity
 import xyz.attacktive.wallhavend.domain.model.query.Sorting
 import xyz.attacktive.wallhavend.domain.model.query.ToplistRange
@@ -58,6 +59,49 @@ class SettingsRepositoryTest {
 		assertEquals(setOf(Purity.SFW), settings.purity)
 		assertEquals(Sorting.RANDOM, settings.sorting)
 		assertEquals(ToplistRange.ONE_MONTH, settings.toplistRange)
+		assertEquals(setOf(WallpaperSource.WALLHAVEN), settings.enabledSources)
+		assertEquals(LicenseFilter.PUBLIC_DOMAIN, settings.licenseFilter)
+	}
+
+	@Test
+	fun `an install that predates a second source keeps rotating Wallhaven alone`() = runTest {
+		val dataStore = PreferenceDataStoreFactory.create(
+			scope = backgroundScope,
+			produceFile = { tmpFolder.newFile("legacy_sources.preferences_pb") }
+		)
+
+		dataStore.edit { prefs -> prefs[stringPreferencesKey("search_query")] = "mountains" }
+
+		val repository = SettingsRepository(dataStore, FakeAppLogger())
+
+		assertEquals(setOf(WallpaperSource.WALLHAVEN), repository.settings.first().enabledSources)
+	}
+
+	@Test
+	fun `enabled sources and the licence tier round-trip`() = runTest {
+		val repository = createRepository()
+		val bothSources = setOf(WallpaperSource.WALLHAVEN, WallpaperSource.OPENVERSE)
+
+		repository.save(AppSettings(searchQuery = "marker", enabledSources = bothSources, licenseFilter = LicenseFilter.ANY_COMMERCIAL))
+
+		val loaded = repository.settings.first { it.searchQuery == "marker" }
+
+		assertEquals(bothSources, loaded.enabledSources)
+		assertEquals(LicenseFilter.ANY_COMMERCIAL, loaded.licenseFilter)
+	}
+
+	@Test
+	fun `a stored source that no longer exists falls back rather than emptying the rotation`() = runTest {
+		val dataStore = PreferenceDataStoreFactory.create(
+			scope = backgroundScope,
+			produceFile = { tmpFolder.newFile("unknown_source.preferences_pb") }
+		)
+
+		dataStore.edit { prefs -> prefs[stringSetPreferencesKey("enabled_sources")] = setOf("someday") }
+
+		val repository = SettingsRepository(dataStore, FakeAppLogger())
+
+		assertEquals(setOf(WallpaperSource.WALLHAVEN), repository.settings.first().enabledSources)
 	}
 
 	@Test

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallhavenProviderTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallhavenProviderTest.kt
@@ -9,9 +9,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import xyz.attacktive.wallhavend.data.api.WallhavenApiService
-import xyz.attacktive.wallhavend.data.api.dto.MetaDto
-import xyz.attacktive.wallhavend.data.api.dto.SearchResponseDto
-import xyz.attacktive.wallhavend.data.api.dto.WallpaperDto
+import xyz.attacktive.wallhavend.data.api.dto.WallhavenMetaDto
+import xyz.attacktive.wallhavend.data.api.dto.WallhavenSearchResponseDto
+import xyz.attacktive.wallhavend.data.api.dto.WallhavenWallpaperDto
 import xyz.attacktive.wallhavend.domain.model.AppSettings
 import xyz.attacktive.wallhavend.domain.model.NoResultsException
 import xyz.attacktive.wallhavend.domain.model.ScreenInfo
@@ -27,9 +27,9 @@ class WallhavenProviderTest {
 	private val portraitScreen = ScreenInfo("9x16", 1080, 2400)
 	private val landscapeScreen = ScreenInfo("16x9", 2400, 1080)
 
-	private fun makeDto(id: String) = WallpaperDto(id, "https://wallhaven.cc/$id", "https://cdn/w/$id.jpg", "1920x1080")
+	private fun makeDto(id: String) = WallhavenWallpaperDto(id, "https://cdn/w/$id.jpg", "1920x1080")
 
-	private fun makePage(count: Int, currentPage: Int = 1, lastPage: Int = 1, idPrefix: String = "w"): SearchResponseDto {
+	private fun makePage(count: Int, currentPage: Int = 1, lastPage: Int = 1, idPrefix: String = "w"): WallhavenSearchResponseDto {
 		val data = (1..count)
 			.map {
 				val id = if (currentPage == 1 && lastPage == 1) {
@@ -41,7 +41,7 @@ class WallhavenProviderTest {
 				makeDto(id)
 			}
 
-		return SearchResponseDto(data, MetaDto(currentPage, lastPage, 24, count))
+		return WallhavenSearchResponseDto(data, WallhavenMetaDto(currentPage, lastPage, 24, count))
 	}
 
 	@Before

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallpaperFileManagerTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallpaperFileManagerTest.kt
@@ -39,7 +39,6 @@ class WallpaperFileManagerTest {
 
 	private fun makeWallpaper(id: String, path: String) = Wallpaper(
 		identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, id),
-		pageUrl = "https://wallhaven.cc/w/$id",
 		directUrl = server.url(path).toString(),
 		resolution = "1920x1080"
 	)

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallpaperIdentityTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallpaperIdentityTest.kt
@@ -74,10 +74,34 @@ class WallpaperIdentityTest {
 	}
 
 	@Test
+	fun `an Openverse identity qualifies and round-trips through parse`() {
+		val identity = WallpaperIdentity(WallpaperSource.OPENVERSE, "422cc250-88fb-4696-81fc-477237e355bd")
+
+		assertEquals("openverse_422cc250-88fb-4696-81fc-477237e355bd", identity.qualified)
+		assertEquals(identity, WallpaperIdentity.parse(identity.qualified))
+	}
+
+	@Test
+	fun `an Openverse id has only the one spelling, since none of them predate qualification`() {
+		val identity = WallpaperIdentity(WallpaperSource.OPENVERSE, "abc-123")
+
+		assertEquals(setOf("openverse_abc-123"), identity.persistedForms)
+		assertFalse(identity.matches(setOf("abc-123")))
+	}
+
+	@Test
 	fun `a Wallhaven identity points at its own page and thumbnail`() {
 		val identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, "abc123")
 
 		assertEquals("https://wallhaven.cc/w/abc123", identity.pageUrl)
 		assertEquals("https://th.wallhaven.cc/lg/ab/abc123.jpg", identity.thumbnailUrl)
+	}
+
+	@Test
+	fun `an Openverse identity points at its Openverse entry and its proxied thumbnail`() {
+		val identity = WallpaperIdentity(WallpaperSource.OPENVERSE, "abc-123")
+
+		assertEquals("https://openverse.org/image/abc-123", identity.pageUrl)
+		assertEquals("https://api.openverse.org/v1/images/abc-123/thumb/", identity.thumbnailUrl)
 	}
 }

--- a/app/src/test/java/xyz/attacktive/wallhavend/WallpaperRepositoryTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/WallpaperRepositoryTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.runTest
 import io.mockk.coEvery
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import xyz.attacktive.wallhavend.domain.model.AppSettings
@@ -31,7 +32,6 @@ class WallpaperRepositoryTest {
 
 	private fun makeWallpaper(id: String) = Wallpaper(
 		identity = WallpaperIdentity(WallpaperSource.WALLHAVEN, id),
-		pageUrl = "https://wallhaven.cc/w/$id",
 		directUrl = "https://cdn/w/$id.jpg",
 		resolution = "1920x1080"
 	)
@@ -109,6 +109,32 @@ class WallpaperRepositoryTest {
 	}
 
 	@Test
+	fun `a source the user has not enabled is never consulted`() = runTest {
+		val wallhaven = FakeWallpaperProvider(Result.failure(NoResultsException()), WallpaperSource.WALLHAVEN)
+		val openverse = FakeWallpaperProvider(Result.failure(NoResultsException()), WallpaperSource.OPENVERSE)
+
+		createRepository(wallhaven, openverse).next(AppSettings(enabledSources = setOf(WallpaperSource.WALLHAVEN)), screen)
+
+		assertTrue(wallhaven.consulted)
+		assertFalse(openverse.consulted)
+	}
+
+	@Test
+	fun `enabling a second source brings it into the rotation`() = runTest {
+		val wallpaper = makeWallpaper("abc123")
+		coEvery { fileManager.download(wallpaper) } returns Result.success(File("/tmp/wallhaven_abc123.jpg"))
+
+		val openverse = FakeWallpaperProvider(Result.success(wallpaper), WallpaperSource.OPENVERSE)
+		val repository = createRepository(FakeWallpaperProvider(Result.failure(NoResultsException())), openverse)
+
+		repeat(shuffleAttempts) {
+			repository.next(AppSettings(enabledSources = setOf(WallpaperSource.WALLHAVEN, WallpaperSource.OPENVERSE)), screen)
+		}
+
+		assertTrue(openverse.consulted)
+	}
+
+	@Test
 	fun `blocked ids reach a source stripped of the qualifying prefix`() = runTest {
 		val provider = FakeWallpaperProvider(Result.failure(NoResultsException()))
 		val blockedIds = setOf("wallhaven_abc123", "def456")
@@ -119,14 +145,16 @@ class WallpaperRepositoryTest {
 	}
 }
 
-/** Stands in for a source: hands back a fixed outcome and records the blocked ids it was given. */
-private class FakeWallpaperProvider(private val result: Result<Wallpaper>): WallpaperProvider {
-	override val source = WallpaperSource.WALLHAVEN
-
+/** Stands in for a source: hands back a fixed outcome and records whether — and with which blocked ids — it was consulted. */
+private class FakeWallpaperProvider(private val result: Result<Wallpaper>, override val source: WallpaperSource = WallpaperSource.WALLHAVEN): WallpaperProvider {
 	var receivedBlockedIds: Set<String>? = null
 		private set
 
+	var consulted = false
+		private set
+
 	override suspend fun next(settings: AppSettings, screenInfo: ScreenInfo, blockedIds: Set<String>): Result<Wallpaper> {
+		consulted = true
 		receivedBlockedIds = blockedIds
 
 		return result


### PR DESCRIPTION
Wallhaven was the only place a wallpaper could come from. Openverse indexes Wikimedia Commons, NASA, Flickr and others behind one key-less API whose terms, unlike Unsplash's and Pexels', carry no clause against wallpaper apps, so it joins the rotation behind the provider abstraction the previous change put in place.

Sources are opt-in and default to Wallhaven alone, so an existing install rotates exactly what it always did until the user says otherwise. The Wallhaven-only controls — categories, colour, sorting, toplist range, API key — fold away when Wallhaven is off, and a licence picker appears when Openverse is on, defaulting to the public-domain tier that carries no attribution obligation at all. Each tier names its licences outright rather than leaning on Openverse's license_type grouping, so widening the filter can only ever add licences.

Openverse has no random sort and caps anonymous requests at 20 results a page and 240 deep, so variety comes from picking a random page inside that depth and shuffling within it. Its aspect_ratio filter offers only tall, wide and square, and its size filter only small, medium and large, so "at least as large as the screen" is settled against the width and height each result reports; one that reports neither cannot qualify.

Attribution is per source now, since Openverse's terms require stating that the app is not endorsed or certified by them. The Wallhaven DTOs take a matching prefix now that Openverse's sit beside them, and the query-splitting rule both providers need moved onto AppSettings.