### PR TITLE
fix: widen the Openverse rotation and evict every copy of a wallpaper

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/OpenverseProvider.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/repository/OpenverseProvider.kt
@@ -25,7 +25,11 @@ class OpenverseProvider @Inject constructor(private val openverseApiService: Ope
 	private val mutex = Mutex()
 	private var cache = ArrayDeque<OpenverseImageDto>()
 	private var cacheKey: SearchKey? = null
-	private var pageCount: Int? = null
+
+	/** Sources still worth asking for the current search; one that answers with nothing is struck off rather than asked again. */
+	private var liveSources = SOURCES.toMutableSet()
+
+	private var pageCounts = mutableMapOf<PageWindow, Int>()
 
 	private data class SearchKey(
 		val keywords: List<String>,
@@ -36,6 +40,12 @@ class OpenverseProvider @Inject constructor(private val openverseApiService: Ope
 		val minimumWidth: Int?,
 		val minimumHeight: Int?
 	)
+
+	/**
+	 * The depth cap applies per query, so each keyword and source pairing is its own result window with its own depth.
+	 * Tracking the page count per pairing is what keeps a shallow window from deciding how deep a deep one may go.
+	 */
+	private data class PageWindow(val keyword: String?, val source: String)
 
 	private fun AppSettings.toSearchKey(screenInfo: ScreenInfo) = SearchKey(
 		keywords = keywords,
@@ -65,7 +75,8 @@ class OpenverseProvider @Inject constructor(private val openverseApiService: Ope
 		if (key != cacheKey) {
 			cache.clear()
 			cacheKey = key
-			pageCount = null
+			liveSources = SOURCES.toMutableSet()
+			pageCounts.clear()
 		}
 
 		val selection = runCatching { selectNext(key, blockedIds) }
@@ -77,10 +88,9 @@ class OpenverseProvider @Inject constructor(private val openverseApiService: Ope
 
 	/**
 	 * Blocked wallpapers, records without a downloadable URL, and results too small for the screen are dropped after the fetch, so a page can arrive full and still leave nothing to pick.
-	 * That earns another page rather than a "no results"; only a page the API returned empty — or too many fruitless tries — gives up.
+	 * That earns another page rather than a "no results"; only running out of sources — or too many fruitless tries — gives up.
 	 */
 	private suspend fun selectNext(key: SearchKey, blockedIds: Set<String>): OpenverseImageDto? {
-		val maxRefetches = 5
 		var refetches = 0
 
 		while (true) {
@@ -92,35 +102,42 @@ class OpenverseProvider @Inject constructor(private val openverseApiService: Ope
 				return cache.removeFirst()
 			}
 
-			if (refetches >= maxRefetches) {
+			if (refetches >= MAX_REFETCHES) {
 				return null
 			}
 
-			refetches++
-			val fetchedCount = refetch(key).getOrThrow()
-			if (fetchedCount == 0) {
-				return null
+			val source = liveSources.randomOrNull() ?: return null
+
+			/* An empty answer means this source holds nothing for the search at all, so striking it off costs a try that a source with results shouldn't have to pay for. */
+			if (refetch(key, source).getOrThrow() == 0) {
+				liveSources.remove(source)
+			} else {
+				refetches++
 			}
 		}
 	}
 
-	private suspend fun refetch(key: SearchKey) = runCatching {
+	/**
+	 * One source per fetch, rather than the whole allowlist at once.
+	 * Ranking decides what fits inside a single query's 240, and it favours whichever source indexes the most, so asking for all of them at once buries the rest — a source only becomes reachable by being asked for on its own.
+	 */
+	private suspend fun refetch(key: SearchKey, source: String) = runCatching {
 		val effectiveKeywords: List<String?> = key.keywords.ifEmpty { listOf(null) }
-		val page = pageToFetch()
+		val windows = effectiveKeywords.map { PageWindow(it, source) }
 
 		val responses = coroutineScope {
-			effectiveKeywords
-				.map { keyword ->
+			windows
+				.map { window ->
 					async {
 						openverseApiService.search(
-							query = keyword,
+							query = window.keyword,
 							license = key.license,
-							source = SOURCE_ALLOWLIST,
+							source = window.source,
 							extension = EXTENSIONS,
 							aspectRatio = key.aspectRatio,
 							size = key.size,
 							mature = key.mature,
-							page = page,
+							page = pageToFetch(window),
 							pageSize = PAGE_SIZE
 						)
 					}
@@ -128,8 +145,8 @@ class OpenverseProvider @Inject constructor(private val openverseApiService: Ope
 				.awaitAll()
 		}
 
-		// The narrowest keyword decides how deep the next page may go, since one page number is shared by the whole fan-out.
-		pageCount = responses.minOf { it.pageCount }
+		windows.zip(responses)
+			.forEach { (window, response) -> pageCounts[window] = response.pageCount }
 
 		val results = responses.flatMap { it.results }
 
@@ -143,11 +160,11 @@ class OpenverseProvider @Inject constructor(private val openverseApiService: Ope
 
 	/**
 	 * Openverse has no random sort, so variety comes from where in the result set the fetch lands.
-	 * The first fetch has to be page 1 — nothing yet says how many pages there are — and every one after it picks at random within reach.
+	 * The first fetch of a window has to be page 1 — nothing yet says how deep that window goes — and every one after it picks at random within reach.
 	 */
-	private fun pageToFetch(): Int {
-		val knownPageCount = pageCount ?: return 1
-		val reachablePages = minOf(knownPageCount, MAX_DEPTH / PAGE_SIZE)
+	private fun pageToFetch(window: PageWindow): Int {
+		val knownPageCount = pageCounts[window] ?: return 1
+		val reachablePages = minOf(knownPageCount, MAX_PAGES)
 
 		return (1..reachablePages.coerceAtLeast(1)).random()
 	}
@@ -165,18 +182,23 @@ class OpenverseProvider @Inject constructor(private val openverseApiService: Ope
 	}
 
 	companion object {
-		/** Openverse indexes 52 sources and most are archival — herbarium sheets and scanned postcards make poor wallpapers — so the query names the ones that don't. */
-		private const val SOURCE_ALLOWLIST = "flickr,wikimedia,nasa,spacex,rawpixel,stocksnap"
+		/** Openverse indexes 52 sources and most are archival — herbarium sheets and scanned postcards make poor wallpapers — so the search only ever names one of these. */
+		private val SOURCES = listOf("flickr", "wikimedia", "nasa", "spacex", "rawpixel", "stocksnap")
 
 		/** WallpaperFileManager only accepts JPEG and PNG, so anything else is ruled out server-side instead of downloaded and thrown away. */
 		private const val EXTENSIONS = "jpg,png"
 
 		/**
 		 * Anonymous requests may ask for 20 results at a time and reach 240 results deep.
-		 * An API key would lift both; the app deliberately doesn't carry one.
+		 * An API key lifts only the first: authenticated callers face the same ceiling on total works per query and merely reach it in fewer round trips, so carrying one would buy no extra wallpapers.
+		 * Going deeper needs expanded access, which Openverse grants case by case and can revoke, so the 240 is treated here as a fact about each query rather than a limit to negotiate around.
 		 */
 		private const val PAGE_SIZE = 20
 		private const val MAX_DEPTH = 240
+		private const val MAX_PAGES = MAX_DEPTH / PAGE_SIZE
+
+		/** A page can come back full and still filter down to nothing, so those fetches get a bounded number of retries before the search gives up. */
+		private const val MAX_REFETCHES = 5
 	}
 }
 

--- a/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/ui/home/HomeViewModel.kt
@@ -124,24 +124,36 @@ class HomeViewModel @Inject constructor(
 		}
 	}
 
+	/**
+	 * Everything the wallpaper occupies on disk goes, not just the path the caller happened to hold.
+	 * An install that predates source-qualified filenames can carry the same wallpaper twice, and the local pool is cycled by listing files rather than by consulting the blocklist, so leaving a copy behind would keep serving a wallpaper the user just blocked.
+	 */
 	private suspend fun evictFromPool(path: String) {
-		val file = File(path)
-		settingsRepository.unpin(WallpaperIdentity.parse(file.nameWithoutExtension))
-		file.delete()
+		val identity = WallpaperIdentity.parse(File(path).nameWithoutExtension)
+		settingsRepository.unpin(identity)
+
+		val evicted = fileManager.listAll()
+			.filter { WallpaperIdentity.parse(it.nameWithoutExtension) == identity }
+			.map { it.absolutePath }
+			.toSet() + path
+
+		evicted.forEach { File(it).delete() }
 
 		val state = stateRepository.state.value
-		val newPaths = state.poolPaths - path
+		val newPaths = state.poolPaths - evicted
 
-		val newCurrent = if (state.currentWallpaperPath == path) {
+		val currentPath = state.currentWallpaperPath
+		val newCurrent = if (currentPath != null && currentPath in evicted) {
 			newPaths.firstOrNull()
 		} else {
-			state.currentWallpaperPath
+			currentPath
 		}
 
-		val newPrev = if (state.previousWallpaperPath == path) {
+		val previousPath = state.previousWallpaperPath
+		val newPrev = if (previousPath != null && previousPath in evicted) {
 			newPaths.getOrNull(1)
 		} else {
-			state.previousWallpaperPath
+			previousPath
 		}
 
 		stateRepository.update {

--- a/app/src/test/java/xyz/attacktive/wallhavend/OpenverseProviderTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/OpenverseProviderTest.kt
@@ -61,13 +61,25 @@ class OpenverseProviderTest {
 	}
 
 	@Test
-	fun `an empty result set gives up without another page`() = runTest {
+	fun `a search with nothing anywhere gives up once every source is struck off`() = runTest {
 		everySearch() returns makePage()
 
 		val result = provider.next(AppSettings(), portraitScreen, emptySet())
 
 		assertTrue(result.exceptionOrNull() is NoResultsException)
-		coVerify(exactly = 1) { openverseApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+		coVerify(exactly = SOURCE_COUNT) { openverseApiService.search(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `a source with nothing to offer is struck off rather than ending the search`() = runTest {
+		everySearch() returns makePage()
+		coEvery {
+			openverseApiService.search(any(), any(), "stocksnap", any(), any(), any(), any(), any(), any())
+		} returns makePage(makeImage("survivor"))
+
+		val result = provider.next(AppSettings(), portraitScreen, emptySet())
+
+		assertEquals("survivor", result.getOrNull()?.identity?.id)
 	}
 
 	@Test
@@ -170,12 +182,25 @@ class OpenverseProviderTest {
 	}
 
 	@Test
-	fun `only JPEG and PNG are asked for, and only from the curated sources`() = runTest {
+	fun `only JPEG and PNG are asked for`() = runTest {
 		everySearch() returns makePage(makeImage("w1"))
 
 		provider.next(AppSettings(), portraitScreen, emptySet())
 
-		coVerify { openverseApiService.search(any(), any(), "flickr,wikimedia,nasa,spacex,rawpixel,stocksnap", "jpg,png", any(), any(), any(), any(), any()) }
+		coVerify { openverseApiService.search(any(), any(), any(), "jpg,png", any(), any(), any(), any(), any()) }
+	}
+
+	@Test
+	fun `each fetch names a single curated source, and the rotation reaches more than one`() = runTest {
+		val requestedSources = mutableListOf<String>()
+		coEvery {
+			openverseApiService.search(any(), any(), capture(requestedSources), any(), any(), any(), any(), any(), any())
+		} returns makePage(makeImage("w1"))
+
+		repeat(30) { provider.next(AppSettings(), portraitScreen, emptySet()) }
+
+		assertTrue(requestedSources.all { it in CURATED_SOURCES })
+		assertTrue("asking one source at a time is what makes the others reachable", requestedSources.distinct().size > 1)
 	}
 
 	@Test
@@ -268,18 +293,44 @@ class OpenverseProviderTest {
 	}
 
 	@Test
-	fun `the narrowest keyword decides how deep the shared page number may go`() = runTest {
+	fun `a keyword with nothing behind it no longer pins the others to the first page`() = runTest {
 		val requestedPages = mutableListOf<Int>()
 		coEvery {
-			openverseApiService.search("wide", any(), any(), any(), any(), any(), any(), any(), any())
-		} returns makePage(makeImage("w1"), pageCount = 500)
+			openverseApiService.search("barren", any(), any(), any(), any(), any(), any(), any(), any())
+		} returns makePage(pageCount = 0)
 
 		coEvery {
-			openverseApiService.search("narrow", any(), any(), any(), any(), any(), any(), capture(requestedPages), any())
+			openverseApiService.search("plentiful", any(), any(), any(), any(), any(), any(), capture(requestedPages), any())
+		} returns makePage(makeImage("w1"), pageCount = 500)
+
+		repeat(20) { provider.next(AppSettings(searchQuery = "barren, plentiful"), portraitScreen, emptySet()) }
+
+		assertTrue(requestedPages.all { it in 1..12 })
+		assertFalse("a keyword that matches nothing should not bound one that matches plenty", requestedPages.all { it == 1 })
+	}
+
+	@Test
+	fun `a shallow source does not bound how deep a richer one is paged`() = runTest {
+		val shallowPages = mutableListOf<Int>()
+		val deepPages = mutableListOf<Int>()
+		everySearch() returns makePage(makeImage("w1"), pageCount = 500)
+		coEvery {
+			openverseApiService.search(any(), any(), "nasa", any(), any(), any(), any(), capture(shallowPages), any())
 		} returns makePage(makeImage("n1"), pageCount = 2)
 
-		repeat(20) { provider.next(AppSettings(searchQuery = "wide, narrow"), portraitScreen, emptySet()) }
+		coEvery {
+			openverseApiService.search(any(), any(), "stocksnap", any(), any(), any(), any(), capture(deepPages), any())
+		} returns makePage(makeImage("s1"), pageCount = 500)
 
-		assertTrue(requestedPages.all { it in 1..2 })
+		/* Enough draws that the rotation is overwhelmingly likely to have visited both sources several times. */
+		repeat(120) { provider.next(AppSettings(), portraitScreen, emptySet()) }
+
+		assertTrue(shallowPages.all { it in 1..2 })
+		assertFalse("each source's own depth is what bounds it", deepPages.all { it in 1..2 })
+	}
+
+	companion object {
+		private val CURATED_SOURCES = setOf("flickr", "wikimedia", "nasa", "spacex", "rawpixel", "stocksnap")
+		private val SOURCE_COUNT = CURATED_SOURCES.size
 	}
 }


### PR DESCRIPTION
Openverse caps every query at 240 works, and the provider varied only the page number within that one query. Measured against the live API, that reaches far less than it looks like it does. The six-source allowlist sent as a single query returns 240 works whose first page is entirely Wikimedia — matching what `source=wikimedia` alone returns — while rawpixel and stocksnap each hold their own untouched 240 that ranking buries. With "avoid blurry wallpapers" on, flickr, nasa and spacex return nothing at all, so half the allowlist was contributing nothing to a window the other half had already filled.

Since the cap applies per query rather than per corpus, a fetch now names a single source drawn at random. Each source's window becomes reachable on its own terms, and the source variety the combined query never delivered falls out of the rotation instead of needing a mechanism of its own. A source that answers with nothing is struck off for the rest of the search rather than asked again — one wasted request each, and no hardcoded knowledge of which sources Openverse currently indexes under which filters.

Page counts moved from a single shared value to one per keyword-and-source pairing. A keyword matching nothing reports a page count of zero, and the minimum across the keyword fan-out then pinned every keyword to page one, so one fruitless keyword quietly collapsed the whole rotation to a single page.

Separately, Block and Delete both handed `evictFromPool` the path they happened to be showing, and it deleted exactly that file. An install predating source-qualified filenames can hold the same wallpaper twice, and the local pool is cycled by listing files rather than by consulting the blocklist, so the surviving copy kept coming round after the user had blocked it. Eviction now matches on the parsed identity and removes every file that resolves to it.

### Trade-off

A search that genuinely matches nothing anywhere now costs one request per source — six, times the keyword count — before it reports "no results", where it used to give up after one. That is the price of not hardcoding which sources are currently empty, and it only happens on searches that were going to fail regardless.

Closes #109, closes #110, closes #115, closes #116.

Mitigates #108 without closing it: the 240 ceiling is still there, it just applies to each source separately now rather than to the rotation as a whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lmng5wTjVpMRrr1Fv7JMxy
