### PR TITLE
fix: measure the screen in its natural orientation, not the current rotation

### DIFF
--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/model/ScreenInfo.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/model/ScreenInfo.kt
@@ -1,3 +1,15 @@
 package xyz.attacktive.wallhavend.domain.model
 
+import android.view.Surface
+
 data class ScreenInfo(val aspectRatio: String, val width: Int, val height: Int)
+
+/**
+ * Android reports the display's size in its current rotation, but wallpapers are for the natural orientation, so a measurement taken a quarter-turn sideways is swapped back rather than trusted.
+ * Deliberately not min/max: a landscape-natural display reports landscape at [Surface.ROTATION_0], and wide is the right thing to ask for there.
+ */
+fun naturalDimensions(width: Int, height: Int, rotation: Int) = if (rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270) {
+	height to width
+} else {
+	width to height
+}

--- a/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
+++ b/app/src/main/java/xyz/attacktive/wallhavend/domain/service/WallpaperService.kt
@@ -27,10 +27,12 @@ import android.app.Service
 import android.app.WallpaperManager
 import android.content.Context
 import android.content.Intent
+import android.hardware.display.DisplayManager
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.util.DisplayMetrics
+import android.view.Display
 import android.view.WindowManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
@@ -50,6 +52,7 @@ import xyz.attacktive.wallhavend.domain.model.WallpaperIdentity
 import xyz.attacktive.wallhavend.domain.model.WallpaperSource
 import xyz.attacktive.wallhavend.domain.model.WallpaperTarget
 import xyz.attacktive.wallhavend.domain.model.closestAspectRatio
+import xyz.attacktive.wallhavend.domain.model.naturalDimensions
 import xyz.attacktive.wallhavend.domain.repository.ServiceStateRepository
 import xyz.attacktive.wallhavend.domain.repository.SettingsRepository
 import xyz.attacktive.wallhavend.domain.repository.WallpaperRepository
@@ -284,12 +287,19 @@ class WallpaperService: Service() {
 	private fun screenInfo(): ScreenInfo {
 		val windowManager = getSystemService(WindowManager::class.java)
 
-		val (width, height) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+		val (measuredWidth, measuredHeight) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
 			val bounds = windowManager.currentWindowMetrics.bounds
 			bounds.width() to bounds.height()
 		} else {
 			legacyScreenDimensions(windowManager)
 		}
+
+		// DisplayManager is the one rotation source that works from a service context on every supported API level; Context.getDisplay() rejects non-visual contexts like this one and WindowManager.defaultDisplay is deprecated.
+		val rotation = getSystemService(DisplayManager::class.java)
+			.getDisplay(Display.DEFAULT_DISPLAY)
+			.rotation
+
+		val (width, height) = naturalDimensions(measuredWidth, measuredHeight, rotation)
 
 		return ScreenInfo(closestAspectRatio(width, height), width, height)
 	}

--- a/app/src/test/java/xyz/attacktive/wallhavend/NaturalDimensionsTest.kt
+++ b/app/src/test/java/xyz/attacktive/wallhavend/NaturalDimensionsTest.kt
@@ -1,0 +1,33 @@
+package xyz.attacktive.wallhavend
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import android.view.Surface
+import xyz.attacktive.wallhavend.domain.model.naturalDimensions
+
+class NaturalDimensionsTest {
+	@Test
+	fun `an upright display is reported as measured`() {
+		assertEquals(1080 to 2400, naturalDimensions(1080, 2400, Surface.ROTATION_0))
+	}
+
+	@Test
+	fun `a quarter turn clockwise swaps the measurement back`() {
+		assertEquals(1080 to 2400, naturalDimensions(2400, 1080, Surface.ROTATION_90))
+	}
+
+	@Test
+	fun `a quarter turn counterclockwise swaps the measurement back`() {
+		assertEquals(1080 to 2400, naturalDimensions(2400, 1080, Surface.ROTATION_270))
+	}
+
+	@Test
+	fun `an upside-down display is reported as measured`() {
+		assertEquals(1080 to 2400, naturalDimensions(1080, 2400, Surface.ROTATION_180))
+	}
+
+	@Test
+	fun `a landscape-natural display stays landscape rather than being forced portrait`() {
+		assertEquals(1280 to 800, naturalDimensions(1280, 800, Surface.ROTATION_0))
+	}
+}


### PR DESCRIPTION
Fixes #121.

A fetch that fired while the device was held sideways inherited the rotated screen measurement, so every query dimension swapped: Wallhaven was asked for `ratios=21x9`, Openverse for `aspect_ratio=wide`, and with "avoid blurry wallpapers" on the minimums demanded 2400 of width and only 1080 of height. Both APIs honour orientation faithfully (measured: 100/100 and 24/24 purity when asked for portrait), so the landscape files in the pool were exactly what the app requested.

`screenInfo()` now runs the measurement through `naturalDimensions()`, a pure helper that swaps the axes back when the display reports a quarter-turn rotation. The rotation comes from `DisplayManager`, the one source that works from a service context on every supported API level. Deliberately not a min/max normalisation: a landscape-natural display reports landscape at rotation 0, and wide is the right thing to ask for there.

Landscape files already on disk are left alone — they trim out newest-first, and deleting or blocking one from the preview evicts every copy since #115.

A note on what happened meanwhile: your macOS session pinged me for a status summary while I was mid-fix — I sent it the branch name, the files in flight, and a porting note (the rotation bug itself has no macOS twin, but if it ports the Openverse provider it should port the 2.0.1 one-source-per-fetch behavior, not the pre-#110 combined query).

The work itself, recapped: issue #121 documents the root cause with today's purity measurements; the fix is on bugfix/natural-orientation-screen-info (one commit, d5304d1) — a 5-test TDD'd naturalDimensions() helper in ScreenInfo.kt plus the rotation compensation in WallpaperService.screenInfo(). Full gate ran green before push: 131 unit tests, assembleDebug, assembleRelease.

Once the PR is open and its checks pass, say the word and I'll do the ff-merge — and presumably a 2.0.2 after, since this one's user-visible.